### PR TITLE
Upgrading CRoaring to HEAD.

### DIFF
--- a/croaring-sys/CRoaring/roaring.c
+++ b/croaring-sys/CRoaring/roaring.c
@@ -1,8 +1,3927 @@
-/* auto-generated on Mon Aug 22 21:49:42 EEST 2016. Do not edit! */
+/* auto-generated on Fri Sep  2 21:26:08 EDT 2016. Do not edit! */
 #line 1 "roaring.c"
 #include "roaring.h"
-/* begin file /Users/saulius/repos/CRoaring/src/array_util.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/array_util.c"
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/convert.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/convert.c"
+#include <stdio.h>
+
+
+// file contains grubby stuff that must know impl. details of all container
+// types.
+bitset_container_t *bitset_container_from_array(const array_container_t *a) {
+    bitset_container_t *ans = bitset_container_create();
+    int limit = array_container_cardinality(a);
+    for (int i = 0; i < limit; ++i) bitset_container_set(ans, a->array[i]);
+    return ans;
+}
+
+bitset_container_t *bitset_container_from_run(const run_container_t *arr) {
+    int card = run_container_cardinality(arr);
+    bitset_container_t *answer = bitset_container_create();
+    for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
+        rle16_t vl = arr->runs[rlepos];
+        bitset_set_lenrange(answer->array, vl.value, vl.length);
+    }
+    answer->cardinality = card;
+    return answer;
+}
+
+array_container_t *array_container_from_run(const run_container_t *arr) {
+    array_container_t *answer =
+        array_container_create_given_capacity(run_container_cardinality(arr));
+    answer->cardinality = 0;
+    for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
+        int run_start = arr->runs[rlepos].value;
+        int run_end = run_start + arr->runs[rlepos].length;
+
+        for (int run_value = run_start; run_value <= run_end; ++run_value) {
+            answer->array[answer->cardinality++] = (uint16_t)run_value;
+        }
+    }
+    return answer;
+}
+
+array_container_t *array_container_from_bitset(const bitset_container_t *bits) {
+    array_container_t *result =
+        array_container_create_given_capacity(bits->cardinality);
+    result->cardinality = bits->cardinality;
+    //  sse version ends up being slower here
+    // (bitset_extract_setbits_sse_uint16)
+    // because of the sparsity of the data
+    bitset_extract_setbits_uint16(bits->array, BITSET_CONTAINER_SIZE_IN_WORDS,
+                                  result->array, 0);
+    return result;
+}
+
+/* assumes that container has adequate space.  Run from [s,e] (inclusive) */
+static void add_run(run_container_t *r, int s, int e) {
+    r->runs[r->n_runs].value = s;
+    r->runs[r->n_runs].length = e - s;
+    r->n_runs++;
+}
+
+run_container_t *run_container_from_array(const array_container_t *c) {
+    int32_t n_runs = array_container_number_of_runs(c);
+    run_container_t *answer = run_container_create_given_capacity(n_runs);
+    int prev = -2;
+    int run_start = -1;
+    int32_t card = c->cardinality;
+    if (card == 0) return answer;
+    for (int i = 0; i < card; ++i) {
+        const uint16_t cur_val = c->array[i];
+        if (cur_val != prev + 1) {
+            // new run starts; flush old one, if any
+            if (run_start != -1) add_run(answer, run_start, prev);
+            run_start = cur_val;
+        }
+        prev = c->array[i];
+    }
+    // now prev is the last seen value
+    add_run(answer, run_start, prev);
+    // assert(run_container_cardinality(answer) == c->cardinality);
+    return answer;
+}
+
+/**
+ * Convert the runcontainer to either a Bitmap or an Array Container, depending
+ * on the cardinality.  Frees the container.
+ * Allocates and returns new container, which caller is responsible for freeing
+ */
+
+void *convert_to_bitset_or_array_container(run_container_t *r, int32_t card,
+                                           uint8_t *resulttype) {
+    if (card <= DEFAULT_MAX_SIZE) {
+        array_container_t *answer = array_container_create_given_capacity(card);
+        answer->cardinality = 0;
+        for (int rlepos = 0; rlepos < r->n_runs; ++rlepos) {
+            uint16_t run_start = r->runs[rlepos].value;
+            uint16_t run_end = run_start + r->runs[rlepos].length;
+            for (uint16_t run_value = run_start; run_value <= run_end;
+                 ++run_value) {
+                answer->array[answer->cardinality++] = run_value;
+            }
+        }
+        assert(card == answer->cardinality);
+        *resulttype = ARRAY_CONTAINER_TYPE_CODE;
+        run_container_free(r);
+        return answer;
+    }
+    bitset_container_t *answer = bitset_container_create();
+    for (int rlepos = 0; rlepos < r->n_runs; ++rlepos) {
+        uint16_t run_start = r->runs[rlepos].value;
+        bitset_set_lenrange(answer->array, run_start, r->runs[rlepos].length);
+    }
+    answer->cardinality = card;
+    *resulttype = BITSET_CONTAINER_TYPE_CODE;
+    run_container_free(r);
+    return answer;
+}
+
+/* Converts a run container to either an array or a bitset, IF it saves space.
+ */
+/* If a conversion occurs, the caller is responsible to free the original
+ * container and
+ * he becomes responsible to free the new one. */
+void *convert_run_to_efficient_container(run_container_t *c,
+                                         uint8_t *typecode_after) {
+    int32_t size_as_run_container =
+        run_container_serialized_size_in_bytes(c->n_runs);
+
+    int32_t size_as_bitset_container =
+        bitset_container_serialized_size_in_bytes();
+    int32_t card = run_container_cardinality(c);
+    int32_t size_as_array_container =
+        array_container_serialized_size_in_bytes(card);
+
+    int32_t min_size_non_run =
+        size_as_bitset_container < size_as_array_container
+            ? size_as_bitset_container
+            : size_as_array_container;
+    if (size_as_run_container <= min_size_non_run) {  // no conversion
+        *typecode_after = RUN_CONTAINER_TYPE_CODE;
+        return c;
+    }
+    if (card <= DEFAULT_MAX_SIZE) {
+        // to array
+        array_container_t *answer = array_container_create_given_capacity(card);
+        answer->cardinality = 0;
+        for (int rlepos = 0; rlepos < c->n_runs; ++rlepos) {
+            int run_start = c->runs[rlepos].value;
+            int run_end = run_start + c->runs[rlepos].length;
+
+            for (int run_value = run_start; run_value <= run_end; ++run_value) {
+                answer->array[answer->cardinality++] = (uint16_t)run_value;
+            }
+        }
+        *typecode_after = ARRAY_CONTAINER_TYPE_CODE;
+        return answer;
+    }
+
+    // else to bitset
+    bitset_container_t *answer = bitset_container_create();
+
+    for (int rlepos = 0; rlepos < c->n_runs; ++rlepos) {
+        int start = c->runs[rlepos].value;
+        int end = start + c->runs[rlepos].length;
+        bitset_set_range(answer->array, start, end + 1);
+    }
+    answer->cardinality = card;
+    *typecode_after = BITSET_CONTAINER_TYPE_CODE;
+    return answer;
+}
+
+// like convert_run_to_efficient_container but frees the old result if needed
+void *convert_run_to_efficient_container_and_free(run_container_t *c,
+                                                  uint8_t *typecode_after) {
+    void *answer = convert_run_to_efficient_container(c, typecode_after);
+    if (answer != c) run_container_free(c);
+    return answer;
+}
+
+/* once converted, the original container is disposed here, rather than
+   in roaring_array
+*/
+
+// TODO: split into run-  array-  and bitset-  subfunctions for sanity;
+// a few function calls won't really matter.
+
+void *convert_run_optimize(void *c, uint8_t typecode_original,
+                           uint8_t *typecode_after) {
+    if (typecode_original == RUN_CONTAINER_TYPE_CODE) {
+        void *newc = convert_run_to_efficient_container((run_container_t *)c,
+                                                        typecode_after);
+        if (newc != c) {
+            container_free(c, typecode_original);
+        }
+        return newc;
+    } else if (typecode_original == ARRAY_CONTAINER_TYPE_CODE) {
+        // it might need to be converted to a run container.
+        array_container_t *c_qua_array = (array_container_t *)c;
+        int32_t n_runs = array_container_number_of_runs(c_qua_array);
+        int32_t size_as_run_container =
+            run_container_serialized_size_in_bytes(n_runs);
+        int32_t card = array_container_cardinality(c_qua_array);
+        int32_t size_as_array_container =
+            array_container_serialized_size_in_bytes(card);
+
+        if (size_as_run_container >= size_as_array_container) {
+            *typecode_after = ARRAY_CONTAINER_TYPE_CODE;
+            return c;
+        }
+        // else convert array to run container
+        run_container_t *answer = run_container_create_given_capacity(n_runs);
+        int prev = -2;
+        int run_start = -1;
+
+        assert(card > 0);
+        for (int i = 0; i < card; ++i) {
+            uint16_t cur_val = c_qua_array->array[i];
+            if (cur_val != prev + 1) {
+                // new run starts; flush old one, if any
+                if (run_start != -1) add_run(answer, run_start, prev);
+                run_start = cur_val;
+            }
+            prev = c_qua_array->array[i];
+        }
+        assert(run_start >= 0);
+        // now prev is the last seen value
+        add_run(answer, run_start, prev);
+        *typecode_after = RUN_CONTAINER_TYPE_CODE;
+        array_container_free(c_qua_array);
+        return answer;
+    } else if (typecode_original ==
+               BITSET_CONTAINER_TYPE_CODE) {  // run conversions on bitset
+        // does bitset need conversion to run?
+        bitset_container_t *c_qua_bitset = (bitset_container_t *)c;
+        int32_t n_runs = bitset_container_number_of_runs(c_qua_bitset);
+        int32_t size_as_run_container =
+            run_container_serialized_size_in_bytes(n_runs);
+        int32_t size_as_bitset_container =
+            bitset_container_serialized_size_in_bytes();
+
+        if (size_as_bitset_container <= size_as_run_container) {
+            // no conversion needed.
+            *typecode_after = BITSET_CONTAINER_TYPE_CODE;
+            return c;
+        }
+        // bitset to runcontainer (ported from Java  RunContainer(
+        // BitmapContainer bc, int nbrRuns))
+        assert(n_runs > 0);  // no empty bitmaps
+        run_container_t *answer = run_container_create_given_capacity(n_runs);
+
+        int long_ctr = 0;
+        uint64_t cur_word = c_qua_bitset->array[0];
+        int run_count = 0;
+        while (true) {
+            while (cur_word == UINT64_C(0) &&
+                   long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
+                cur_word = c_qua_bitset->array[++long_ctr];
+
+            if (cur_word == UINT64_C(0)) {
+                bitset_container_free(c_qua_bitset);
+                *typecode_after = RUN_CONTAINER_TYPE_CODE;
+                return answer;
+            }
+
+            int local_run_start = __builtin_ctzll(cur_word);
+            int run_start = local_run_start + 64 * long_ctr;
+            uint64_t cur_word_with_1s = cur_word | (cur_word - 1);
+
+            int run_end = 0;
+            while (cur_word_with_1s == UINT64_C(-1) &&
+                   long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
+                cur_word_with_1s = c_qua_bitset->array[++long_ctr];
+
+            if (cur_word_with_1s == UINT64_C(-1)) {
+                run_end = 64 + long_ctr * 64;  // exclusive, I guess
+                add_run(answer, run_start, run_end - 1);
+                bitset_container_free(c_qua_bitset);
+                *typecode_after = RUN_CONTAINER_TYPE_CODE;
+                return answer;
+            }
+            int local_run_end = __builtin_ctzll(~cur_word_with_1s);
+            run_end = local_run_end + long_ctr * 64;
+            add_run(answer, run_start, run_end - 1);
+            run_count++;
+            cur_word = cur_word_with_1s & (cur_word_with_1s + 1);
+        }
+        return answer;
+    } else {
+        assert(false);
+        __builtin_unreachable();
+        return NULL;
+    }
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/convert.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_andnot.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_andnot.c"
+/*
+ * mixed_andnot.c.  More methods since operation is not symmetric,
+ * except no "wide" andnot , so no lazy options motivated.
+ */
+
+#include <assert.h>
+#include <string.h>
+
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst, a valid array container that could be the same as dst.*/
+void array_bitset_container_andnot(const array_container_t *src_1,
+                                   const bitset_container_t *src_2,
+                                   array_container_t *dst) {
+    // follows Java implementation as of June 2016
+    if (dst->capacity < src_1->cardinality)
+        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    int32_t newcard = 0;
+    const int32_t origcard = src_1->cardinality;
+    for (int i = 0; i < origcard; ++i) {
+        uint16_t key = src_1->array[i];
+        if (!bitset_container_contains(src_2, key)) {
+            dst->array[newcard++] = key;
+        }
+    }
+    dst->cardinality = newcard;
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * src_1 */
+
+void array_bitset_container_iandnot(array_container_t *src_1,
+                                    const bitset_container_t *src_2) {
+    array_bitset_container_andnot(src_1, src_2, src_1);
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst, which does not initially have a valid container.
+ * Return true for a bitset result; false for array
+ */
+
+bool bitset_array_container_andnot(const bitset_container_t *src_1,
+                                   const array_container_t *src_2, void **dst) {
+    // Java did this directly, but we have option of asm or avx
+    bitset_container_t *result = bitset_container_create();
+    bitset_container_copy(src_1, result);
+    result->cardinality = bitset_clear_list(result->array, result->cardinality,
+                                            src_2->array, src_2->cardinality);
+
+    // do required type conversions.
+    if (result->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(result);
+        bitset_container_free(result);
+        return false;
+    }
+    *dst = result;
+    return true;
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+bool bitset_array_container_iandnot(bitset_container_t *src_1,
+                                    const array_container_t *src_2,
+                                    void **dst) {
+    *dst = src_1;
+    src_1->cardinality = bitset_clear_list(src_1->array, src_1->cardinality,
+                                           src_2->array, src_2->cardinality);
+
+    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(src_1);
+        bitset_container_free(src_1);
+        return false;  // not bitset
+    } else
+        return true;
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst. Result may be either a bitset or an array container
+ * (returns "result is bitset"). dst does not initially have
+ * any container, but becomes either a bitset container (return
+ * result true) or an array container.
+ */
+
+bool run_bitset_container_andnot(const run_container_t *src_1,
+                                 const bitset_container_t *src_2, void **dst) {
+    // follows the Java implementation as of June 2016
+    int card = run_container_cardinality(src_1);
+    if (card <= DEFAULT_MAX_SIZE) {
+        // must be an array
+        array_container_t *answer = array_container_create_given_capacity(card);
+        answer->cardinality = 0;
+        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+            rle16_t rle = src_1->runs[rlepos];
+            for (int run_value = rle.value; run_value <= rle.value + rle.length;
+                 ++run_value) {
+                if (!bitset_container_get(src_2, (uint16_t)run_value)) {
+                    answer->array[answer->cardinality++] = (uint16_t)run_value;
+                }
+            }
+        }
+        *dst = answer;
+        return false;
+    } else {  // we guess it will be a bitset, though have to check guess when
+              // done
+        bitset_container_t *answer = bitset_container_clone(src_2);
+
+        uint32_t last_pos = 0;
+        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+            rle16_t rle = src_1->runs[rlepos];
+
+            uint32_t start = rle.value;
+            uint32_t end = start + rle.length + 1;
+            bitset_reset_range(answer->array, last_pos, start);
+            bitset_flip_range(answer->array, start, end);
+            last_pos = end;
+        }
+        bitset_reset_range(answer->array, last_pos, (uint32_t)(1 << 16));
+
+        answer->cardinality = bitset_container_compute_cardinality(answer);
+
+        if (answer->cardinality <= DEFAULT_MAX_SIZE) {
+            *dst = array_container_from_bitset(answer);
+            bitset_container_free(answer);
+            return false;  // not bitset
+        }
+        *dst = answer;
+        return true;  // bitset
+    }
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst. Result may be either a bitset or an array container
+ * (returns "result is bitset"). dst does not initially have
+ * any container, but becomes either a bitset container (return
+ * result true) or an array container.
+ */
+
+bool run_bitset_container_iandnot(run_container_t *src_1,
+                                  const bitset_container_t *src_2, void **dst) {
+    // dummy implementation
+    bool ans = run_bitset_container_andnot(src_1, src_2, dst);
+    run_container_free(src_1);
+    return ans;
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst. Result may be either a bitset or an array container
+ * (returns "result is bitset").  dst does not initially have
+ * any container, but becomes either a bitset container (return
+ * result true) or an array container.
+ */
+
+bool bitset_run_container_andnot(const bitset_container_t *src_1,
+                                 const run_container_t *src_2, void **dst) {
+    // follows Java implementation
+    bitset_container_t *result = bitset_container_create();
+
+    bitset_container_copy(src_1, result);
+    for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
+        rle16_t rle = src_2->runs[rlepos];
+        bitset_reset_range(result->array, rle.value,
+                           rle.value + rle.length + UINT32_C(1));
+    }
+    result->cardinality = bitset_container_compute_cardinality(result);
+
+    if (result->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(result);
+        bitset_container_free(result);
+        return false;  // not bitset
+    }
+    *dst = result;
+    return true;  // bitset
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+bool bitset_run_container_iandnot(bitset_container_t *src_1,
+                                  const run_container_t *src_2, void **dst) {
+    *dst = src_1;
+
+    for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
+        rle16_t rle = src_2->runs[rlepos];
+        bitset_reset_range(src_1->array, rle.value,
+                           rle.value + rle.length + UINT32_C(1));
+    }
+    src_1->cardinality = bitset_container_compute_cardinality(src_1);
+
+    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(src_1);
+        bitset_container_free(src_1);
+        return false;  // not bitset
+    } else
+        return true;
+}
+
+/* helper. a_out must be a valid array container with adequate capacity.
+ * Returns the cardinality of the output container. Partly Based on Java
+ * implementation Util.unsignedDifference.
+ *
+ * TODO: Util.unsignedDifference does not use advanceUntil.  Is it cheaper
+ * to avoid advanceUntil?
+ */
+
+static int run_array_array_subtract(const run_container_t *r,
+                                    const array_container_t *a_in,
+                                    array_container_t *a_out) {
+    int out_card = 0;
+    int32_t in_array_pos =
+        -1;  // since advanceUntil always assumes we start the search AFTER this
+
+    for (int rlepos = 0; rlepos < r->n_runs; rlepos++) {
+        int32_t start = r->runs[rlepos].value;
+        int32_t end = start + r->runs[rlepos].length + 1;
+
+        in_array_pos = advanceUntil(a_in->array, in_array_pos,
+                                    a_in->cardinality, (uint16_t)start);
+
+        if (in_array_pos >= a_in->cardinality) {  // run has no items subtracted
+            for (int32_t i = start; i < end; ++i)
+                a_out->array[out_card++] = (uint16_t)i;
+        } else {
+            uint16_t next_nonincluded = a_in->array[in_array_pos];
+            if (next_nonincluded >= end) {
+                // another case when run goes unaltered
+                for (int32_t i = start; i < end; ++i)
+                    a_out->array[out_card++] = (uint16_t)i;
+                in_array_pos--;  // ensure we see this item again if necessary
+            } else {
+                for (int32_t i = start; i < end; ++i)
+                    if (i != next_nonincluded)
+                        a_out->array[out_card++] = (uint16_t)i;
+                    else  // 0 should ensure  we don't match
+                        next_nonincluded =
+                            (in_array_pos + 1 >= a_in->cardinality)
+                                ? 0
+                                : a_in->array[++in_array_pos];
+                in_array_pos--;  // see again
+            }
+        }
+    }
+    return out_card;
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any type of container.
+ */
+
+int run_array_container_andnot(const run_container_t *src_1,
+                               const array_container_t *src_2, void **dst) {
+    // follows the Java impl as of June 2016
+
+    int card = run_container_cardinality(src_1);
+    const int arbitrary_threshold = 32;
+
+    if (card <= arbitrary_threshold) {
+        if (src_2->cardinality == 0) {
+            *dst = run_container_clone(src_1);
+            return RUN_CONTAINER_TYPE_CODE;
+        }
+        // Java's "lazyandNot.toEfficientContainer" thing
+        run_container_t *answer = run_container_create_given_capacity(
+            card + array_container_cardinality(src_2));
+
+        int rlepos = 0;
+        int xrlepos = 0;  // "x" is src_2
+        rle16_t rle = src_1->runs[rlepos];
+        int32_t start = rle.value;
+        int32_t end = start + rle.length + 1;
+        int32_t xstart = src_2->array[xrlepos];
+
+        while ((rlepos < src_1->n_runs) && (xrlepos < src_2->cardinality)) {
+            if (end <= xstart) {
+                // output the first run
+                answer->runs[answer->n_runs++] =
+                    (rle16_t){.value = (uint16_t)start,
+                              .length = (uint16_t)(end - start - 1)};
+                rlepos++;
+                if (rlepos < src_1->n_runs) {
+                    start = src_1->runs[rlepos].value;
+                    end = start + src_1->runs[rlepos].length + 1;
+                }
+            } else if (xstart + 1 <= start) {
+                // exit the second run
+                xrlepos++;
+                if (xrlepos < src_2->cardinality) {
+                    xstart = src_2->array[xrlepos];
+                }
+            } else {
+                if (start < xstart) {
+                    answer->runs[answer->n_runs++] =
+                        (rle16_t){.value = (uint16_t)start,
+                                  .length = (uint16_t)(xstart - start - 1)};
+                }
+                if (xstart + 1 < end) {
+                    start = xstart + 1;
+                } else {
+                    rlepos++;
+                    if (rlepos < src_1->n_runs) {
+                        start = src_1->runs[rlepos].value;
+                        end = start + src_1->runs[rlepos].length + 1;
+                    }
+                }
+            }
+        }
+        if (rlepos < src_1->n_runs) {
+            answer->runs[answer->n_runs++] =
+                (rle16_t){.value = (uint16_t)start,
+                          .length = (uint16_t)(end - start - 1)};
+            rlepos++;
+            if (rlepos < src_1->n_runs) {
+                memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,
+                       (src_1->n_runs - rlepos) * sizeof(rle16_t));
+                answer->n_runs += (src_1->n_runs - rlepos);
+            }
+        }
+        uint8_t return_type;
+        *dst = convert_run_to_efficient_container(answer, &return_type);
+        if (answer != *dst) run_container_free(answer);
+        return return_type;
+    }
+    // else it's a bitmap or array
+
+    if (card <= DEFAULT_MAX_SIZE) {
+        array_container_t *ac = array_container_create_given_capacity(card);
+        // nb Java code used a generic iterator-based merge to compute
+        // difference
+        ac->cardinality = run_array_array_subtract(src_1, src_2, ac);
+        *dst = ac;
+        return ARRAY_CONTAINER_TYPE_CODE;
+    }
+    bitset_container_t *ans = bitset_container_from_run(src_1);
+    bool result_is_bitset = bitset_array_container_iandnot(ans, src_2, dst);
+    return (result_is_bitset ? BITSET_CONTAINER_TYPE_CODE
+                             : ARRAY_CONTAINER_TYPE_CODE);
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+int run_array_container_iandnot(run_container_t *src_1,
+                                const array_container_t *src_2, void **dst) {
+    // dummy implementation same as June 2016 Java
+    int ans = run_array_container_andnot(src_1, src_2, dst);
+    run_container_free(src_1);
+    return ans;
+}
+
+/* dst must be a valid array container, allowed to be src_1 */
+
+void array_run_container_andnot(const array_container_t *src_1,
+                                const run_container_t *src_2,
+                                array_container_t *dst) {
+    // basically following Java impl as of June 2016
+    if (src_1->cardinality > dst->capacity)
+        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+
+    if (src_2->n_runs == 0) {
+        memmove(dst->array, src_1->array,
+                sizeof(uint16_t) * src_1->cardinality);
+        dst->cardinality = src_1->cardinality;
+        return;
+    }
+    int32_t run_start = src_2->runs[0].value;
+    int32_t run_end = run_start + src_2->runs[0].length;
+    int which_run = 0;
+
+    uint16_t val = 0;
+    int dest_card = 0;
+    for (int i = 0; i < src_1->cardinality; ++i) {
+        val = src_1->array[i];
+        if (val < run_start)
+            dst->array[dest_card++] = val;
+        else if (val <= run_end) {
+            ;  // omitted item
+        } else {
+            do {
+                if (which_run + 1 < src_2->n_runs) {
+                    ++which_run;
+                    run_start = src_2->runs[which_run].value;
+                    run_end = run_start + src_2->runs[which_run].length;
+
+                } else
+                    run_start = run_end = (1 << 16) + 1;
+            } while (val > run_end);
+            --i;
+        }
+    }
+    dst->cardinality = dest_card;
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any kind of container.
+ */
+
+void array_run_container_iandnot(array_container_t *src_1,
+                                 const run_container_t *src_2) {
+    array_run_container_andnot(src_1, src_2, src_1);
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any kind of container.
+ */
+
+int run_run_container_andnot(const run_container_t *src_1,
+                             const run_container_t *src_2, void **dst) {
+    run_container_t *ans = run_container_create();
+    run_container_andnot(src_1, src_2, ans);
+    uint8_t typecode_after;
+    *dst = convert_run_to_efficient_container_and_free(ans, &typecode_after);
+    return typecode_after;
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+int run_run_container_iandnot(run_container_t *src_1,
+                              const run_container_t *src_2, void **dst) {
+    // following Java impl as of June 2016 (dummy)
+    int ans = run_run_container_andnot(src_1, src_2, dst);
+    run_container_free(src_1);
+    return ans;
+}
+
+/*
+ * dst is a valid array container and may be the same as src_1
+ */
+
+void array_array_container_andnot(const array_container_t *src_1,
+                                  const array_container_t *src_2,
+                                  array_container_t *dst) {
+    array_container_andnot(src_1, src_2, dst);
+}
+
+/* inplace array-array andnot will always be able to reuse the space of
+ * src_1 */
+void array_array_container_iandnot(array_container_t *src_1,
+                                   const array_container_t *src_2) {
+    array_container_andnot(src_1, src_2, src_1);
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially). Return value is
+ * "dst is a bitset"
+ */
+
+bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
+                                    const bitset_container_t *src_2,
+                                    void **dst) {
+    bitset_container_t *ans = bitset_container_create();
+    int card = bitset_container_andnot(src_1, src_2, ans);
+    if (card <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(ans);
+        bitset_container_free(ans);
+        return false;  // not bitset
+    } else {
+        *dst = ans;
+        return true;
+    }
+}
+
+/* Compute the andnot of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
+                                     const bitset_container_t *src_2,
+                                     void **dst) {
+    int card = bitset_container_andnot(src_1, src_2, src_1);
+    if (card <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(src_1);
+        bitset_container_free(src_1);
+        return false;  // not bitset
+    } else {
+        *dst = src_1;
+        return true;
+    }
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_andnot.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_negation.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_negation.c"
+/*
+ * mixed_negation.c
+ *
+ */
+
+#include <assert.h>
+#include <string.h>
+
+
+// TODO: make simplified and optimized negation code across
+// the full range.
+
+/* Negation across the entire range of the container.
+ * Compute the  negation of src  and write the result
+ * to *dst. The complement of a
+ * sufficiently sparse set will always be dense and a hence a bitmap
+' * We assume that dst is pre-allocated and a valid bitset container
+ * There can be no in-place version.
+ */
+void array_container_negation(const array_container_t *src,
+                              bitset_container_t *dst) {
+    uint64_t card = UINT64_C(1 << 16);
+    bitset_container_set_all(dst);
+
+    dst->cardinality =
+        bitset_clear_list(dst->array, card, src->array, src->cardinality);
+}
+
+/* Negation across the entire range of the container
+ * Compute the  negation of src  and write the result
+ * to *dst.  A true return value indicates a bitset result,
+ * otherwise the result is an array container.
+ *  We assume that dst is not pre-allocated. In
+ * case of failure, *dst will be NULL.
+ */
+bool bitset_container_negation(const bitset_container_t *src, void **dst) {
+    return bitset_container_negation_range(src, 0, (1 << 16), dst);
+}
+
+/* inplace version */
+/*
+ * Same as bitset_container_negation except that if the output is to
+ * be a
+ * bitset_container_t, then src is modified and no allocation is made.
+ * If the output is to be an array_container_t, then caller is responsible
+ * to free the container.
+ * In all cases, the result is in *dst.
+ */
+bool bitset_container_negation_inplace(bitset_container_t *src, void **dst) {
+    return bitset_container_negation_range_inplace(src, 0, (1 << 16), dst);
+}
+
+/* Negation across the entire range of container
+ * Compute the  negation of src  and write the result
+ * to *dst.  Return values are the *_TYPECODES as defined * in containers.h
+ *  We assume that dst is not pre-allocated. In
+ * case of failure, *dst will be NULL.
+ */
+int run_container_negation(const run_container_t *src, void **dst) {
+    return run_container_negation_range(src, 0, (1 << 16), dst);
+}
+
+/*
+ * Same as run_container_negation except that if the output is to
+ * be a
+ * run_container_t, and has the capacity to hold the result,
+ * then src is modified and no allocation is made.
+ * In all cases, the result is in *dst.
+ */
+int run_container_negation_inplace(run_container_t *src, void **dst) {
+    return run_container_negation_range_inplace(src, 0, (1 << 16), dst);
+}
+
+/* Negation across a range of the container.
+ * Compute the  negation of src  and write the result
+ * to *dst. Returns true if the result is a bitset container
+ * and false for an array container.  *dst is not preallocated.
+ */
+bool array_container_negation_range(const array_container_t *src,
+                                    const int range_start, const int range_end,
+                                    void **dst) {
+    /* close port of the Java implementation */
+    if (range_start >= range_end) {
+        *dst = array_container_clone(src);
+        return false;
+    }
+
+    int32_t start_index =
+        binarySearch(src->array, src->cardinality, (uint16_t)range_start);
+    if (start_index < 0) start_index = -start_index - 1;
+
+    int32_t last_index =
+        binarySearch(src->array, src->cardinality, (uint16_t)(range_end - 1));
+    if (last_index < 0) last_index = -last_index - 2;
+
+    const int32_t current_values_in_range = last_index - start_index + 1;
+    const int32_t span_to_be_flipped = range_end - range_start;
+    const int32_t new_values_in_range =
+        span_to_be_flipped - current_values_in_range;
+    const int32_t cardinality_change =
+        new_values_in_range - current_values_in_range;
+    const int32_t new_cardinality = src->cardinality + cardinality_change;
+
+    if (new_cardinality > DEFAULT_MAX_SIZE) {
+        bitset_container_t *temp = bitset_container_from_array(src);
+        bitset_flip_range(temp->array, (uint32_t)range_start,
+                          (uint32_t)range_end);
+        temp->cardinality = new_cardinality;
+        *dst = temp;
+        return true;
+    }
+
+    array_container_t *arr =
+        array_container_create_given_capacity(new_cardinality);
+    *dst = (void *)arr;
+    // copy stuff before the active area
+    memcpy(arr->array, src->array, start_index * sizeof(uint16_t));
+
+    // work on the range
+    int32_t out_pos = start_index, in_pos = start_index;
+    int32_t val_in_range = range_start;
+    for (; val_in_range < range_end && in_pos <= last_index; ++val_in_range) {
+        if ((uint16_t)val_in_range != src->array[in_pos]) {
+            arr->array[out_pos++] = (uint16_t)val_in_range;
+        } else {
+            ++in_pos;
+        }
+    }
+    for (; val_in_range < range_end; ++val_in_range)
+        arr->array[out_pos++] = (uint16_t)val_in_range;
+
+    // content after the active range
+    memcpy(arr->array + out_pos, src->array + (last_index + 1),
+           (src->cardinality - (last_index + 1)) * sizeof(uint16_t));
+    arr->cardinality = new_cardinality;
+    return false;
+}
+
+/* Even when the result would fit, it is unclear how to make an
+ * inplace version without inefficient copying.
+ */
+
+bool array_container_negation_range_inplace(array_container_t *src,
+                                            const int range_start,
+                                            const int range_end, void **dst) {
+    bool ans = array_container_negation_range(src, range_start, range_end, dst);
+    // TODO : try a real inplace version
+    array_container_free(src);
+    return ans;
+}
+
+/* Negation across a range of the container
+ * Compute the  negation of src  and write the result
+ * to *dst.  A true return value indicates a bitset result,
+ * otherwise the result is an array container.
+ *  We assume that dst is not pre-allocated. In
+ * case of failure, *dst will be NULL.
+ */
+bool bitset_container_negation_range(const bitset_container_t *src,
+                                     const int range_start, const int range_end,
+                                     void **dst) {
+    // TODO maybe consider density-based estimate
+    // and sometimes build result directly as array, with
+    // conversion back to bitset if wrong.  Or determine
+    // actual result cardinality, then go directly for the known final cont.
+
+    // keep computation using bitsets as long as possible.
+    bitset_container_t *t = bitset_container_clone(src);
+    bitset_flip_range(t->array, (uint32_t)range_start, (uint32_t)range_end);
+    t->cardinality = bitset_container_compute_cardinality(t);
+
+    if (t->cardinality > DEFAULT_MAX_SIZE) {
+        *dst = t;
+        return true;
+    } else {
+        *dst = array_container_from_bitset(t);
+        bitset_container_free(t);
+        return false;
+    }
+}
+
+/* inplace version */
+/*
+ * Same as bitset_container_negation except that if the output is to
+ * be a
+ * bitset_container_t, then src is modified and no allocation is made.
+ * If the output is to be an array_container_t, then caller is responsible
+ * to free the container.
+ * In all cases, the result is in *dst.
+ */
+bool bitset_container_negation_range_inplace(bitset_container_t *src,
+                                             const int range_start,
+                                             const int range_end, void **dst) {
+    bitset_flip_range(src->array, (uint32_t)range_start, (uint32_t)range_end);
+    src->cardinality = bitset_container_compute_cardinality(src);
+    if (src->cardinality > DEFAULT_MAX_SIZE) {
+        *dst = src;
+        return true;
+    }
+    *dst = array_container_from_bitset(src);
+    bitset_container_free(src);
+    return false;
+}
+
+/* Negation across a range of container
+ * Compute the  negation of src  and write the result
+ * to *dst. Return values are the *_TYPECODES as defined * in containers.h
+ *  We assume that dst is not pre-allocated. In
+ * case of failure, *dst will be NULL.
+ */
+int run_container_negation_range(const run_container_t *src,
+                                 const int range_start, const int range_end,
+                                 void **dst) {
+    uint8_t return_typecode;
+
+    // follows the Java implementation
+    if (range_end <= range_start) {
+        *dst = run_container_clone(src);
+        return RUN_CONTAINER_TYPE_CODE;
+    }
+
+    run_container_t *ans = run_container_create_given_capacity(
+        src->n_runs + 1);  // src->n_runs + 1);
+    int k = 0;
+    for (; k < src->n_runs && src->runs[k].value < range_start; ++k) {
+        ans->runs[k] = src->runs[k];
+        ans->n_runs++;
+    }
+
+    run_container_smart_append_exclusive(
+        ans, (uint16_t)range_start, (uint16_t)(range_end - range_start - 1));
+
+    for (; k < src->n_runs; ++k) {
+        run_container_smart_append_exclusive(ans, src->runs[k].value,
+                                             src->runs[k].length);
+    }
+
+    *dst = convert_run_to_efficient_container(ans, &return_typecode);
+    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
+
+    return return_typecode;
+}
+
+/*
+ * Same as run_container_negation except that if the output is to
+ * be a
+ * run_container_t, and has the capacity to hold the result,
+ * then src is modified and no allocation is made.
+ * In all cases, the result is in *dst.
+ */
+int run_container_negation_range_inplace(run_container_t *src,
+                                         const int range_start,
+                                         const int range_end, void **dst) {
+    uint8_t return_typecode;
+
+    if (range_end <= range_start) {
+        *dst = src;
+        return RUN_CONTAINER_TYPE_CODE;
+    }
+
+    // TODO: efficient special case when range is 0 to 65535 inclusive
+
+    if (src->capacity == src->n_runs) {
+        // no excess room.  More checking to see if result can fit
+        bool last_val_before_range = false;
+        bool first_val_in_range = false;
+        bool last_val_in_range = false;
+        bool first_val_past_range = false;
+
+        if (range_start > 0)
+            last_val_before_range =
+                run_container_contains(src, (uint16_t)(range_start - 1));
+        first_val_in_range = run_container_contains(src, (uint16_t)range_start);
+
+        if (last_val_before_range == first_val_in_range) {
+            last_val_in_range =
+                run_container_contains(src, (uint16_t)(range_end - 1));
+            if (range_end != 0x10000)
+                first_val_past_range =
+                    run_container_contains(src, (uint16_t)range_end);
+
+            if (last_val_in_range ==
+                first_val_past_range) {  // no space for inplace
+                int ans = run_container_negation_range(src, range_start,
+                                                       range_end, dst);
+                run_container_free(src);
+                return ans;
+            }
+        }
+    }
+    // all other cases: result will fit
+
+    run_container_t *ans = src;
+    int my_nbr_runs = src->n_runs;
+
+    ans->n_runs = 0;
+    int k = 0;
+    for (; (k < my_nbr_runs) && (src->runs[k].value < range_start); ++k) {
+        // ans->runs[k] = src->runs[k]; (would be self-copy)
+        ans->n_runs++;
+    }
+
+    // as with Java implementation, use locals to give self a buffer of depth 1
+    rle16_t buffered = (rle16_t){.value = (uint16_t)0, .length = (uint16_t)0};
+    rle16_t next = buffered;
+    if (k < my_nbr_runs) buffered = src->runs[k];
+
+    run_container_smart_append_exclusive(
+        ans, (uint16_t)range_start, (uint16_t)(range_end - range_start - 1));
+
+    for (; k < my_nbr_runs; ++k) {
+        if (k + 1 < my_nbr_runs) next = src->runs[k + 1];
+
+        run_container_smart_append_exclusive(ans, buffered.value,
+                                             buffered.length);
+        buffered = next;
+    }
+
+    *dst = convert_run_to_efficient_container(ans, &return_typecode);
+    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
+
+    return return_typecode;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_negation.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/array.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/array.c"
+/*
+ * array.c
+ *
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+extern inline bool array_container_contains(const array_container_t *arr,
+                                             uint16_t pos);
+extern int array_container_cardinality(const array_container_t *array);
+extern bool array_container_nonzero_cardinality(const array_container_t *array);
+extern void array_container_clear(array_container_t *array);
+extern int32_t array_container_serialized_size_in_bytes(int32_t card);
+extern bool array_container_empty(const array_container_t *array);
+extern bool array_container_full(const array_container_t *array);
+
+/* Create a new array with capacity size. Return NULL in case of failure. */
+array_container_t *array_container_create_given_capacity(int32_t size) {
+    array_container_t *container;
+
+    if ((container = (array_container_t *)malloc(sizeof(array_container_t))) ==
+        NULL) {
+        return NULL;
+    }
+
+    if ((container->array = (uint16_t *)malloc(sizeof(uint16_t) * size)) ==
+        NULL) {
+        free(container);
+        return NULL;
+    }
+
+    container->capacity = size;
+    container->cardinality = 0;
+
+    return container;
+}
+
+/* Create a new array. Return NULL in case of failure. */
+array_container_t *array_container_create() {
+    return array_container_create_given_capacity(ARRAY_DEFAULT_INIT_SIZE);
+}
+
+/* Duplicate container */
+array_container_t *array_container_clone(const array_container_t *src) {
+    array_container_t *newcontainer =
+        array_container_create_given_capacity(src->capacity);
+    if (newcontainer == NULL) return NULL;
+
+    newcontainer->cardinality = src->cardinality;
+
+    memcpy(newcontainer->array, src->array,
+           src->cardinality * sizeof(uint16_t));
+
+    return newcontainer;
+}
+
+/* Free memory. */
+void array_container_free(array_container_t *arr) {
+    free(arr->array);
+    arr->array = NULL;
+    free(arr);
+}
+
+static inline int32_t grow_capacity(int32_t capacity) {
+    return (capacity <= 0) ? ARRAY_DEFAULT_INIT_SIZE
+                           : capacity < 64 ? capacity * 2
+                                           : capacity < 1024 ? capacity * 3 / 2
+                                                             : capacity * 5 / 4;
+}
+
+static inline int32_t clamp(int32_t val, int32_t min, int32_t max) {
+    return ((val < min) ? min : (val > max) ? max : val);
+}
+
+/**
+ * increase capacity to at least min, and to no more than max. Whether the
+ * existing data needs to be copied over depends on the "preserve" parameter. If
+ * preserve is false,
+ * then the new content will be uninitialized, otherwise the old content is
+ * copie.
+ */
+void array_container_grow(array_container_t *container, int32_t min,
+                          int32_t max, bool preserve) {
+    int32_t new_capacity = clamp(grow_capacity(container->capacity), min, max);
+
+    // currently uses set max to INT32_MAX.  The next statement is not so useful
+    // then.
+    // if we are within 1/16th of the max, go to max
+    if (new_capacity > max - max / 16) new_capacity = max;
+
+    container->capacity = new_capacity;
+    uint16_t *array = container->array;
+
+    if (preserve) {
+        container->array =
+            (uint16_t *)realloc(array, new_capacity * sizeof(uint16_t));
+        if (container->array == NULL) free(array);
+    } else {
+        free(array);
+        container->array = (uint16_t *)malloc(new_capacity * sizeof(uint16_t));
+    }
+
+    // TODO: handle the case where realloc fails
+    assert(container->array != NULL);
+}
+
+/* Copy one container into another. We assume that they are distinct. */
+void array_container_copy(const array_container_t *src,
+                          array_container_t *dst) {
+    const int32_t cardinality = src->cardinality;
+    if (cardinality > dst->capacity) {
+        array_container_grow(dst, cardinality, INT32_MAX, false);
+    }
+
+    dst->cardinality = cardinality;
+    memcpy(dst->array, src->array, cardinality * sizeof(uint16_t));
+}
+
+void array_container_add_from_range(array_container_t *arr, uint32_t min,
+                                    uint32_t max, uint16_t step) {
+    for (uint32_t value = min; value < max; value += step) {
+        array_container_append(arr, value);
+    }
+}
+
+/* Computes the union of array1 and array2 and write the result to arrayout.
+ * It is assumed that arrayout is distinct from both array1 and array2.
+ */
+void array_container_union(const array_container_t *array_1,
+                           const array_container_t *array_2,
+                           array_container_t *out) {
+    const int32_t card_1 = array_1->cardinality, card_2 = array_2->cardinality;
+    const int32_t max_cardinality = card_1 + card_2;
+
+    if (out->capacity < max_cardinality)
+        array_container_grow(out, max_cardinality, INT32_MAX, false);
+#ifdef ROARING_VECTOR_UNION_ENABLED
+    // compute union with smallest array first
+    if (card_1 < card_2) {
+        out->cardinality = union_vector16(array_1->array, card_1,
+                                          array_2->array, card_2, out->array);
+    } else {
+        out->cardinality = union_vector16(array_2->array, card_2,
+                                          array_1->array, card_1, out->array);
+    }
+#else
+    // compute union with smallest array first
+    if (card_1 < card_2) {
+        out->cardinality = union_uint16(array_1->array, card_1, array_2->array,
+                                        card_2, out->array);
+    } else {
+        out->cardinality = union_uint16(array_2->array, card_2, array_1->array,
+                                        card_1, out->array);
+    }
+#endif
+}
+
+/* helper. a_out must be a valid array container with adequate capacity.
+ * and may be same as a1.
+ * Returns the cardinality of the output container. Based on Java
+ * implementation Util.unsignedDifference
+ */
+
+static int array_array_array_subtract(const array_container_t *a1,
+                                      const array_container_t *a2,
+                                      array_container_t *a_out) {
+    int out_card = 0;
+    int k1 = 0, k2 = 0;
+    int length1 = a1->cardinality, length2 = a2->cardinality;
+
+    if (length1 == 0) return 0;
+
+    if (length2 == 0) {
+        if (a1 != a_out)
+            memcpy(a_out->array, a1->array, sizeof(uint16_t) * length1);
+        return length1;
+    }
+
+    uint16_t s1 = a1->array[k1];
+    uint16_t s2 = a2->array[k2];
+
+    while (true) {
+        if (s1 < s2) {
+            a_out->array[out_card++] = s1;
+            ++k1;
+            if (k1 >= length1) {
+                break;
+            }
+            s1 = a1->array[k1];
+        } else if (s1 == s2) {
+            ++k1;
+            ++k2;
+            if (k1 >= length1) {
+                break;
+            }
+            if (k2 >= length2) {
+                memmove(a_out->array + out_card, a1->array + k1,
+                        sizeof(uint16_t) * (length1 - k1));
+                return out_card + length1 - k1;
+            }
+            s1 = a1->array[k1];
+            s2 = a2->array[k2];
+        } else {  // if (val1>val2)
+            ++k2;
+            if (k2 >= length2) {
+                memmove(a_out->array + out_card, a1->array + k1,
+                        sizeof(uint16_t) * (length1 - k1));
+                return out_card + length1 - k1;
+            }
+            s2 = a2->array[k2];
+        }
+    }
+    return out_card;
+}
+
+/* Computes the  difference of array1 and array2 and write the result
+ * to array out.
+ * Array out does not need to be distinct from array_1
+ */
+void array_container_andnot(const array_container_t *array_1,
+                            const array_container_t *array_2,
+                            array_container_t *out) {
+    if (out->capacity < array_1->cardinality)
+        array_container_grow(out, array_1->cardinality, INT32_MAX, false);
+    out->cardinality = array_array_array_subtract(array_1, array_2, out);
+}
+
+/* Computes the symmetric difference of array1 and array2 and write the
+ * result
+ * to arrayout.
+ * It is assumed that arrayout is distinct from both array1 and array2.
+ */
+void array_container_xor(const array_container_t *array_1,
+                         const array_container_t *array_2,
+                         array_container_t *out) {
+    const int32_t card_1 = array_1->cardinality, card_2 = array_2->cardinality;
+    const int32_t max_cardinality = card_1 + card_2;
+
+    if (out->capacity < max_cardinality)
+        array_container_grow(out, max_cardinality, INT32_MAX, false);
+
+    // TODO something clever like the AVX union in array_util.c
+    // except where *both* occurrences of a duplicate in a sorted sequence
+    // are removed.
+
+    // just a merge for now (see TODO)
+    int pos1 = 0, pos2 = 0, pos_out = 0;
+    while (pos1 < card_1 && pos2 < card_2) {
+        const uint16_t v1 = array_1->array[pos1];
+        const uint16_t v2 = array_2->array[pos2];
+        if (v1 == v2) {
+            ++pos1;
+            ++pos2;
+            continue;
+        }
+        if (v1 < v2) {
+            out->array[pos_out++] = v1;
+            ++pos1;
+        } else {
+            out->array[pos_out++] = v2;
+            ++pos2;
+        }
+    }
+    // todo: memcpys instead
+    while (pos1 < card_1) out->array[pos_out++] = array_1->array[pos1++];
+    while (pos2 < card_2) out->array[pos_out++] = array_2->array[pos2++];
+
+    out->cardinality = pos_out;
+}
+
+static inline int32_t minimum_int32(int32_t a, int32_t b) {
+    return (a < b) ? a : b;
+}
+
+/* computes the intersection of array1 and array2 and write the result to
+ * arrayout.
+ * It is assumed that arrayout is distinct from both array1 and array2.
+ * */
+void array_container_intersection(const array_container_t *array1,
+                                  const array_container_t *array2,
+                                  array_container_t *out) {
+    int32_t card_1 = array1->cardinality, card_2 = array2->cardinality,
+            min_card = minimum_int32(card_1, card_2);
+    const int threshold = 64;  // subject to tuning
+#ifdef USEAVX
+    min_card += sizeof(__m128i) / sizeof(uint16_t);
+#endif
+    if (out->capacity < min_card)
+        array_container_grow(out, min_card, INT32_MAX, false);
+    if (card_1 * threshold < card_2) {
+        out->cardinality = intersect_skewed_uint16(
+            array1->array, card_1, array2->array, card_2, out->array);
+    } else if (card_2 * threshold < card_1) {
+        out->cardinality = intersect_skewed_uint16(
+            array2->array, card_2, array1->array, card_1, out->array);
+    } else {
+#ifdef USEAVX
+        out->cardinality = intersect_vector16(
+            array1->array, card_1, array2->array, card_2, out->array);
+#else
+        out->cardinality = intersect_uint16(array1->array, card_1,
+                                            array2->array, card_2, out->array);
+#endif
+    }
+}
+
+/* computes the intersection of array1 and array2 and write the result to
+ * array1.
+ * */
+void array_container_intersection_inplace(array_container_t *src_1,
+                                          const array_container_t *src_2) {
+    // todo: can any of this be vectorized?
+    int32_t card_1 = src_1->cardinality, card_2 = src_2->cardinality;
+    const int threshold = 64;  // subject to tuning
+    if (card_1 * threshold < card_2) {
+        src_1->cardinality = intersect_skewed_uint16(
+            src_1->array, card_1, src_2->array, card_2, src_1->array);
+    } else if (card_2 * threshold < card_1) {
+        src_1->cardinality = intersect_skewed_uint16(
+            src_2->array, card_2, src_1->array, card_1, src_1->array);
+    } else {
+        src_1->cardinality = intersect_uint16(
+            src_1->array, card_1, src_2->array, card_2, src_1->array);
+    }
+}
+
+int array_container_to_uint32_array(void *vout,
+                                    const array_container_t *cont,
+                                    uint32_t base) {
+    int outpos = 0;
+    uint32_t * out = (uint32_t *) vout;
+    for (int i = 0; i < cont->cardinality; ++i) {
+        const uint32_t val = base + cont->array[i];
+        memcpy(out + outpos, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
+        outpos ++;
+    }
+    return outpos;
+}
+
+void array_container_printf(const array_container_t *v) {
+    if (v->cardinality == 0) {
+        printf("{}");
+        return;
+    }
+    printf("{");
+    printf("%d", v->array[0]);
+    for (int i = 1; i < v->cardinality; ++i) {
+        printf(",%d", v->array[i]);
+    }
+    printf("}");
+}
+
+void array_container_printf_as_uint32_array(const array_container_t *v,
+                                            uint32_t base) {
+    if (v->cardinality == 0) {
+        return;
+    }
+    printf("%d", v->array[0] + base);
+    for (int i = 1; i < v->cardinality; ++i) {
+        printf(",%d", v->array[i] + base);
+    }
+}
+
+/* Compute the number of runs */
+int32_t array_container_number_of_runs(const array_container_t *a) {
+    // Can SIMD work here?
+    int32_t nr_runs = 0;
+    int32_t prev = -2;
+    for (const uint16_t *p = a->array; p != a->array + a->cardinality; ++p) {
+        if (*p != prev + 1) nr_runs++;
+        prev = *p;
+    }
+    return nr_runs;
+}
+
+int32_t array_container_serialize(array_container_t *container, char *buf) {
+    int32_t l, off;
+    uint16_t cardinality = (uint16_t)container->cardinality;
+
+    memcpy(buf, &cardinality, off = sizeof(cardinality));
+    l = sizeof(uint16_t) * container->cardinality;
+    if (l) memcpy(&buf[off], container->array, l);
+
+    return (off + l);
+}
+
+/**
+ * Writes the underlying array to buf, outputs how many bytes were written.
+ * The number of bytes written should be
+ * array_container_size_in_bytes(container).
+ *
+ */
+int32_t array_container_write(const array_container_t *container, char *buf) {
+    memcpy(buf, container->array,
+               container->cardinality * sizeof(uint16_t));
+    return array_container_size_in_bytes(container);
+}
+
+bool array_container_equals(array_container_t *container1,
+                            array_container_t *container2) {
+    if (container1->cardinality != container2->cardinality) {
+        return false;
+    }
+    // could be vectorized:
+    for (int32_t i = 0; i < container1->cardinality; ++i) {
+        if (container1->array[i] != container2->array[i]) return false;
+    }
+    return true;
+}
+
+int32_t array_container_read(int32_t cardinality, array_container_t *container,
+                             const char *buf) {
+    if (container->capacity < cardinality) {
+        array_container_grow(container, cardinality, DEFAULT_MAX_SIZE, false);
+    }
+    container->cardinality = cardinality;
+    memcpy(container->array, buf, container->cardinality * sizeof(uint16_t));
+
+    return array_container_size_in_bytes(container);
+}
+
+uint32_t array_container_serialization_len(array_container_t *container) {
+    return (sizeof(uint16_t) /* container->cardinality converted to 16 bit */ +
+            (sizeof(uint16_t) * container->cardinality));
+}
+
+void *array_container_deserialize(const char *buf, size_t buf_len) {
+    array_container_t *ptr;
+
+    if (buf_len < 2) /* capacity converted to 16 bit */
+        return (NULL);
+    else
+        buf_len -= 2;
+
+    if ((ptr = (array_container_t *)malloc(sizeof(array_container_t))) !=
+        NULL) {
+        size_t len;
+        int32_t off;
+        uint16_t cardinality;
+
+        memcpy(&cardinality, buf, off = sizeof(cardinality));
+
+        ptr->capacity = ptr->cardinality = (uint32_t)cardinality;
+        len = sizeof(uint16_t) * ptr->cardinality;
+
+        if (len != buf_len) {
+            free(ptr);
+            return (NULL);
+        }
+
+        if ((ptr->array = (uint16_t *)malloc(sizeof(uint16_t) *
+                                             ptr->capacity)) == NULL) {
+            free(ptr);
+            return (NULL);
+        }
+
+        if (len) memcpy(ptr->array, &buf[off], len);
+
+        /* Check if returned values are monotonically increasing */
+        for (int32_t i = 0, j = 0; i < ptr->cardinality; i++) {
+            if (ptr->array[i] < j) {
+                free(ptr->array);
+                free(ptr);
+                return (NULL);
+            } else
+                j = ptr->array[i];
+        }
+    }
+
+    return (ptr);
+}
+
+bool array_container_iterate(const array_container_t *cont, uint32_t base,
+                             roaring_iterator iterator, void *ptr) {
+    for (int i = 0; i < cont->cardinality; i++)
+        if (!iterator(cont->array[i] + base, ptr)) return false;
+    return true;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/array.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_union.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_union.c"
+/*
+ * mixed_union.c
+ *
+ */
+
+#include <assert.h>
+#include <string.h>
+
+
+/* Compute the union of src_1 and src_2 and write the result to
+ * dst.  */
+void array_bitset_container_union(const array_container_t *src_1,
+                                  const bitset_container_t *src_2,
+                                  bitset_container_t *dst) {
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    dst->cardinality = bitset_set_list_withcard(
+        dst->array, dst->cardinality, src_1->array, src_1->cardinality);
+}
+
+/* Compute the union of src_1 and src_2 and write the result to
+ * dst. It is allowed for src_2 to be dst.  This version does not
+ * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY). */
+void array_bitset_container_lazy_union(const array_container_t *src_1,
+                                       const bitset_container_t *src_2,
+                                       bitset_container_t *dst) {
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    bitset_set_list(dst->array, src_1->array, src_1->cardinality);
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+}
+
+void run_bitset_container_union(const run_container_t *src_1,
+                                const bitset_container_t *src_2,
+                                bitset_container_t *dst) {
+    assert(!run_container_is_full(src_1));  // catch this case upstream
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+        rle16_t rle = src_1->runs[rlepos];
+        bitset_set_lenrange(dst->array, rle.value, rle.length);
+    }
+    dst->cardinality = bitset_container_compute_cardinality(dst);
+}
+
+void run_bitset_container_lazy_union(const run_container_t *src_1,
+                                     const bitset_container_t *src_2,
+                                     bitset_container_t *dst) {
+    assert(!run_container_is_full(src_1));  // catch this case upstream
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+        rle16_t rle = src_1->runs[rlepos];
+        bitset_set_lenrange(dst->array, rle.value, rle.length);
+    }
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+}
+
+// why do we leave the result as a run container??
+void array_run_container_union(const array_container_t *src_1,
+                               const run_container_t *src_2,
+                               run_container_t *dst) {
+    if (run_container_is_full(src_2)) {
+        run_container_copy(src_2, dst);
+        return;
+    }
+    // TODO: see whether the "2*" is spurious
+    run_container_grow(dst, 2 * (src_1->cardinality + src_2->n_runs), false);
+    int32_t rlepos = 0;
+    int32_t arraypos = 0;
+    rle16_t previousrle;
+    if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
+        previousrle = run_container_append_first(dst, src_2->runs[rlepos]);
+        rlepos++;
+    } else {
+        previousrle =
+            run_container_append_value_first(dst, src_1->array[arraypos]);
+        arraypos++;
+    }
+    while ((rlepos < src_2->n_runs) && (arraypos < src_1->cardinality)) {
+        if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
+            run_container_append(dst, src_2->runs[rlepos], &previousrle);
+            rlepos++;
+        } else {
+            run_container_append_value(dst, src_1->array[arraypos],
+                                       &previousrle);
+            arraypos++;
+        }
+    }
+    if (arraypos < src_1->cardinality) {
+        while (arraypos < src_1->cardinality) {
+            run_container_append_value(dst, src_1->array[arraypos],
+                                       &previousrle);
+            arraypos++;
+        }
+    } else {
+        while (rlepos < src_2->n_runs) {
+            run_container_append(dst, src_2->runs[rlepos], &previousrle);
+            rlepos++;
+        }
+    }
+}
+
+void array_run_container_inplace_union(const array_container_t *src_1,
+                                       run_container_t *src_2) {
+    if (run_container_is_full(src_2)) {
+        return;
+    }
+    const int32_t maxoutput = src_1->cardinality + src_2->n_runs;
+    const int32_t neededcapacity = maxoutput + src_2->n_runs;
+    if (src_2->capacity < neededcapacity)
+        run_container_grow(src_2, neededcapacity, true);
+    memmove(src_2->runs + maxoutput, src_2->runs,
+            src_2->n_runs * sizeof(rle16_t));
+    rle16_t *inputsrc2 = src_2->runs + maxoutput;
+    int32_t rlepos = 0;
+    int32_t arraypos = 0;
+    int src2nruns = src_2->n_runs;
+    src_2->n_runs = 0;
+
+    rle16_t previousrle;
+
+    if (inputsrc2[rlepos].value <= src_1->array[arraypos]) {
+        previousrle = run_container_append_first(src_2, inputsrc2[rlepos]);
+        rlepos++;
+    } else {
+        previousrle =
+            run_container_append_value_first(src_2, src_1->array[arraypos]);
+        arraypos++;
+    }
+
+    while ((rlepos < src2nruns) && (arraypos < src_1->cardinality)) {
+        if (inputsrc2[rlepos].value <= src_1->array[arraypos]) {
+            run_container_append(src_2, inputsrc2[rlepos], &previousrle);
+            rlepos++;
+        } else {
+            run_container_append_value(src_2, src_1->array[arraypos],
+                                       &previousrle);
+            arraypos++;
+        }
+    }
+    if (arraypos < src_1->cardinality) {
+        while (arraypos < src_1->cardinality) {
+            run_container_append_value(src_2, src_1->array[arraypos],
+                                       &previousrle);
+            arraypos++;
+        }
+    } else {
+        while (rlepos < src2nruns) {
+            run_container_append(src_2, inputsrc2[rlepos], &previousrle);
+            rlepos++;
+        }
+    }
+}
+
+bool array_array_container_union(const array_container_t *src_1,
+                                 const array_container_t *src_2, void **dst) {
+    int totalCardinality = src_1->cardinality + src_2->cardinality;
+    if (totalCardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_create_given_capacity(totalCardinality);
+        if (*dst != NULL)
+            array_container_union(src_1, src_2, (array_container_t *)*dst);
+        return false;  // not a bitset
+    }
+    *dst = bitset_container_create();
+    bool returnval = true;  // expect a bitset
+    if (*dst != NULL) {
+        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
+        ourbitset->cardinality =
+            bitset_set_list_withcard(ourbitset->array, src_1->cardinality,
+                                     src_2->array, src_2->cardinality);
+        if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
+            // need to convert!
+            *dst = array_container_from_bitset(ourbitset);
+            bitset_container_free(ourbitset);
+            returnval = false;  // not going to be a bitset
+        }
+    }
+    return returnval;
+}
+
+bool array_array_container_lazy_union(const array_container_t *src_1,
+                                      const array_container_t *src_2,
+                                      void **dst) {
+    int totalCardinality = src_1->cardinality + src_2->cardinality;
+    if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
+        *dst = array_container_create_given_capacity(totalCardinality);
+        if (*dst != NULL)
+            array_container_union(src_1, src_2, (array_container_t *)*dst);
+        return false;  // not a bitset
+    }
+    *dst = bitset_container_create();
+    bool returnval = true;  // expect a bitset
+    if (*dst != NULL) {
+        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
+        bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
+        ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
+    }
+    return returnval;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_union.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/containers.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/containers.c"
+
+
+extern  inline const void *container_unwrap_shared(
+       const void *candidate_shared_container, uint8_t *type);
+
+extern const char *get_container_name(uint8_t typecode);
+
+extern int container_get_cardinality(const void *container, uint8_t typecode);
+
+extern void *container_iand(void *c1, uint8_t type1, const void *c2,
+                            uint8_t type2, uint8_t *result_type);
+
+extern void *container_ior(void *c1, uint8_t type1, const void *c2,
+                           uint8_t type2, uint8_t *result_type);
+
+extern void *container_ixor(void *c1, uint8_t type1, const void *c2,
+                            uint8_t type2, uint8_t *result_type);
+
+extern void *container_iandnot(void *c1, uint8_t type1, const void *c2,
+                               uint8_t type2, uint8_t *result_type);
+
+void container_free(void *container, uint8_t typecode) {
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            bitset_container_free((bitset_container_t *)container);
+            break;
+        case ARRAY_CONTAINER_TYPE_CODE:
+            array_container_free((array_container_t *)container);
+            break;
+        case RUN_CONTAINER_TYPE_CODE:
+            run_container_free((run_container_t *)container);
+            break;
+        case SHARED_CONTAINER_TYPE_CODE:
+            shared_container_free((shared_container_t *)container);
+            break;
+        default:
+            assert(false);
+            __builtin_unreachable();
+    }
+}
+
+void container_printf(const void *container, uint8_t typecode) {
+    container = container_unwrap_shared(container, &typecode);
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            bitset_container_printf((const bitset_container_t *)container);
+            return;
+        case ARRAY_CONTAINER_TYPE_CODE:
+            array_container_printf((const array_container_t *)container);
+            return;
+        case RUN_CONTAINER_TYPE_CODE:
+            run_container_printf((const run_container_t *)container);
+            return;
+        default:
+            __builtin_unreachable();
+    }
+}
+
+void container_printf_as_uint32_array(const void *container, uint8_t typecode,
+                                      uint32_t base) {
+    container = container_unwrap_shared(container, &typecode);
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            bitset_container_printf_as_uint32_array(
+                (const bitset_container_t *)container, base);
+            return;
+        case ARRAY_CONTAINER_TYPE_CODE:
+            array_container_printf_as_uint32_array(
+                (const array_container_t *)container, base);
+            return;
+        case RUN_CONTAINER_TYPE_CODE:
+            run_container_printf_as_uint32_array(
+                (const run_container_t *)container, base);
+            return;
+            return;
+        default:
+            __builtin_unreachable();
+    }
+}
+
+int32_t container_serialize(const void *container, uint8_t typecode,
+                            char *buf) {
+    container = container_unwrap_shared(container, &typecode);
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            return (bitset_container_serialize((bitset_container_t *)container,
+                                               buf));
+        case ARRAY_CONTAINER_TYPE_CODE:
+            return (
+                array_container_serialize((array_container_t *)container, buf));
+        case RUN_CONTAINER_TYPE_CODE:
+            return (run_container_serialize((run_container_t *)container, buf));
+        default:
+            assert(0);
+            __builtin_unreachable();
+            return (-1);
+    }
+}
+
+uint32_t container_serialization_len(const void *container, uint8_t typecode) {
+    container = container_unwrap_shared(container, &typecode);
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            return bitset_container_serialization_len();
+        case ARRAY_CONTAINER_TYPE_CODE:
+            return array_container_serialization_len(
+                (array_container_t *)container);
+        case RUN_CONTAINER_TYPE_CODE:
+            return run_container_serialization_len(
+                (run_container_t *)container);
+        default:
+            assert(0);
+            __builtin_unreachable();
+            return (0);
+    }
+}
+
+void *container_deserialize(uint8_t typecode, const char *buf, size_t buf_len) {
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            return (bitset_container_deserialize(buf, buf_len));
+        case ARRAY_CONTAINER_TYPE_CODE:
+            return (array_container_deserialize(buf, buf_len));
+        case RUN_CONTAINER_TYPE_CODE:
+            return (run_container_deserialize(buf, buf_len));
+        case SHARED_CONTAINER_TYPE_CODE:
+            printf("this should never happen.\n");
+            assert(0);
+            __builtin_unreachable();
+            return (NULL);
+        default:
+            assert(0);
+            __builtin_unreachable();
+            return (NULL);
+    }
+}
+
+extern bool container_nonzero_cardinality(const void *container,
+                                          uint8_t typecode);
+
+extern void container_free(void *container, uint8_t typecode);
+
+extern int container_to_uint32_array(uint32_t *output, const void *container,
+                                     uint8_t typecode, uint32_t base);
+
+extern void *container_add(void *container, uint16_t val, uint8_t typecode,
+                           uint8_t *new_typecode);
+
+extern inline bool container_contains(const void *container, uint16_t val,
+                               uint8_t typecode);
+
+extern void *container_clone(const void *container, uint8_t typecode);
+
+extern void *container_and(const void *c1, uint8_t type1, const void *c2,
+                           uint8_t type2, uint8_t *result_type);
+
+extern void *container_or(const void *c1, uint8_t type1, const void *c2,
+                          uint8_t type2, uint8_t *result_type);
+
+extern void *container_xor(const void *c1, uint8_t type1, const void *c2,
+                           uint8_t type2, uint8_t *result_type);
+
+void *get_copy_of_container(void *container, uint8_t *typecode,
+                            bool copy_on_write) {
+    if (copy_on_write) {
+        shared_container_t *shared_container;
+        if (*typecode == SHARED_CONTAINER_TYPE_CODE) {
+            shared_container = (shared_container_t *)container;
+            shared_container->counter += 1;
+            return shared_container;
+        }
+        assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+
+        if ((shared_container = (shared_container_t *)malloc(
+                 sizeof(shared_container_t))) == NULL) {
+            return NULL;
+        }
+
+        shared_container->container = container;
+        shared_container->typecode = *typecode;
+
+        shared_container->counter = 2;
+        *typecode = SHARED_CONTAINER_TYPE_CODE;
+
+        return shared_container;
+    }  // copy_on_write
+    // otherwise, no copy on write...
+    const void *actualcontainer =
+        container_unwrap_shared((const void *)container, typecode);
+    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+    return container_clone(actualcontainer, *typecode);
+}
+/**
+ * Copies a container, requires a typecode. This allocates new memory, caller
+ * is responsible for deallocation.
+ */
+void *container_clone(const void *container, uint8_t typecode) {
+    container = container_unwrap_shared(container, &typecode);
+    switch (typecode) {
+        case BITSET_CONTAINER_TYPE_CODE:
+            return bitset_container_clone((bitset_container_t *)container);
+        case ARRAY_CONTAINER_TYPE_CODE:
+            return array_container_clone((array_container_t *)container);
+        case RUN_CONTAINER_TYPE_CODE:
+            return run_container_clone((run_container_t *)container);
+        case SHARED_CONTAINER_TYPE_CODE:
+            printf("shared containers are not cloneable\n");
+            assert(false);
+            return NULL;
+        default:
+            assert(false);
+            __builtin_unreachable();
+            return NULL;
+    }
+}
+
+void *shared_container_extract_copy(shared_container_t *container,
+                                    uint8_t *typecode) {
+    assert(container->counter > 0);
+    assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
+    container->counter--;
+    *typecode = container->typecode;
+    void *answer;
+    if (container->counter == 0) {
+        answer = container->container;
+        container->container = NULL;  // paranoid
+        free(container);
+    } else {
+        answer = container_clone(container->container, *typecode);
+    }
+    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
+    return answer;
+}
+
+void shared_container_free(shared_container_t *container) {
+    assert(container->counter > 0);
+    container->counter--;
+    if (container->counter == 0) {
+        assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
+        container_free(container->container, container->typecode);
+        container->container = NULL;  // paranoid
+        free(container);
+    }
+}
+
+extern void *container_not(const void *c1, uint8_t type1, uint8_t *result_type);
+
+extern void *container_not_range(const void *c1, uint8_t type1,
+                                 uint32_t range_start, uint32_t range_end,
+                                 uint8_t *result_type);
+
+extern void *container_inot(void *c1, uint8_t type1, uint8_t *result_type);
+
+extern void *container_inot_range(void *c1, uint8_t type1, uint32_t range_start,
+                                  uint32_t range_end, uint8_t *result_type);
+
+extern void *container_range_of_ones(uint32_t range_start, uint32_t range_end,
+                                     uint8_t *result_type);
+
+// where are the correponding things for union and intersection??
+extern void *container_lazy_xor(const void *c1, uint8_t type1, const void *c2,
+                                uint8_t type2, uint8_t *result_type);
+
+extern void *container_lazy_ixor(void *c1, uint8_t type1, const void *c2,
+                                 uint8_t type2, uint8_t *result_type);
+
+extern void *container_andnot(const void *c1, uint8_t type1, const void *c2,
+                              uint8_t type2, uint8_t *result_type);
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/containers.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/bitset.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/bitset.c"
+/*
+ * bitset.c
+ *
+ */
+#ifndef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE 200809L
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+
+extern int bitset_container_cardinality(const bitset_container_t *bitset);
+extern bool bitset_container_nonzero_cardinality(bitset_container_t *bitset);
+extern void bitset_container_set(bitset_container_t *bitset, uint16_t pos);
+extern void bitset_container_unset(bitset_container_t *bitset, uint16_t pos);
+extern inline bool bitset_container_get(const bitset_container_t *bitset,
+                                 uint16_t pos);
+extern int32_t bitset_container_serialized_size_in_bytes();
+extern bool bitset_container_add(bitset_container_t *bitset, uint16_t pos);
+extern bool bitset_container_remove(bitset_container_t *bitset, uint16_t pos);
+extern bool bitset_container_contains(const bitset_container_t *bitset,
+                                      uint16_t pos);
+
+void bitset_container_clear(bitset_container_t *bitset) {
+    memset(bitset->array, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    bitset->cardinality = 0;
+}
+
+void bitset_container_set_all(bitset_container_t *bitset) {
+    memset(bitset->array, INT64_C(-1),
+           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    bitset->cardinality = (1 << 16);
+}
+
+/* Create a new bitset. Return NULL in case of failure. */
+bitset_container_t *bitset_container_create(void) {
+    bitset_container_t *bitset =
+        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
+
+    if (!bitset) {
+        return NULL;
+    }
+    // sizeof(__m256i) == 32
+    if (posix_memalign((void **)&bitset->array, 32,
+                       sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS)) {
+        free(bitset);
+        return NULL;
+    }
+    bitset_container_clear(bitset);
+    return bitset;
+}
+
+/* Copy one container into another. We assume that they are distinct. */
+void bitset_container_copy(const bitset_container_t *source,
+                           bitset_container_t *dest) {
+    dest->cardinality = source->cardinality;
+    memcpy(dest->array, source->array,
+           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+}
+
+void bitset_container_add_from_range(bitset_container_t *bitset, uint32_t min,
+                                     uint32_t max, uint16_t step) {
+    if (step == 0) return;   // refuse to crash
+    if ((64 % step) == 0) {  // step divides 64
+        uint64_t mask = 0;   // construct the repeated mask
+        for (uint32_t value = (min % step); value < 64; value += step) {
+            mask |= ((uint64_t)1 << value);
+        }
+        uint32_t firstword = min / 64;
+        uint32_t endword = (max - 1) / 64;
+        bitset->cardinality = (max - min + step - 1) / step;
+        if (firstword == endword) {
+            bitset->array[firstword] |=
+                mask & (((~UINT64_C(0)) << (min % 64)) &
+                        ((~UINT64_C(0)) >> ((-max) % 64)));
+            return;
+        }
+        bitset->array[firstword] = mask & ((~UINT64_C(0)) << (min % 64));
+        for (uint32_t i = firstword + 1; i < endword; i++)
+            bitset->array[i] = mask;
+        bitset->array[endword] = mask & ((~UINT64_C(0)) >> ((-max) % 64));
+    } else {
+        for (uint32_t value = min; value < max; value += step) {
+            bitset_container_add(bitset, value);
+        }
+    }
+}
+
+/* Free memory. */
+void bitset_container_free(bitset_container_t *bitset) {
+    free(bitset->array);
+    bitset->array = NULL;
+    free(bitset);
+}
+
+/* duplicate container. */
+bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
+    bitset_container_t *bitset =
+        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
+
+    if (!bitset) {
+        return NULL;
+    }
+    // sizeof(__m256i) == 32
+    if (posix_memalign((void **)&bitset->array, 32,
+                       sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS)) {
+        free(bitset);
+        return NULL;
+    }
+    bitset->cardinality = src->cardinality;
+    memcpy(bitset->array, src->array,
+           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+    return bitset;
+}
+
+void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
+                                uint32_t end) {
+    bitset_set_range(bitset->array, begin, end);
+    bitset->cardinality =
+        bitset_container_compute_cardinality(bitset);  // could be smarter
+}
+
+//#define USEPOPCNT // when this is disabled
+// bitset_container_compute_cardinality uses AVX to compute hamming weight
+
+#ifdef USEAVX
+#ifndef WORDS_IN_AVX2_REG
+#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
+#endif
+/* Get the number of bits set (force computation) */
+int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
+    return avx2_harley_seal_popcount256(
+        (const __m256i *)bitset->array,
+        BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));
+}
+#else
+
+/* Get the number of bits set (force computation) */
+int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
+    const uint64_t *array = bitset->array;
+    int32_t sum = 0;
+    for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 4) {
+        sum += hamming(array[i]);
+        sum += hamming(array[i + 1]);
+        sum += hamming(array[i + 2]);
+        sum += hamming(array[i + 3]);
+    }
+    return sum;
+}
+
+#endif
+
+#ifdef USEAVX
+
+#define BITSET_CONTAINER_FN_REPEAT 8
+#ifndef WORDS_IN_AVX2_REG
+#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
+#endif
+#define LOOP_SIZE                    \
+    BITSET_CONTAINER_SIZE_IN_WORDS / \
+        ((WORDS_IN_AVX2_REG)*BITSET_CONTAINER_FN_REPEAT)
+
+/* Computes a binary operation (eg union) on bitset1 and bitset2 and write the
+   result to bitsetout */
+// clang-format off
+#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic)            \
+int bitset_container_##opname##_nocard(const bitset_container_t *src_1, \
+                                       const bitset_container_t *src_2, \
+                                       bitset_container_t *dst) {       \
+    const uint8_t *array_1 = (const uint8_t *)src_1->array;             \
+    const uint8_t *array_2 = (const uint8_t *)src_2->array;             \
+    /* not using the blocking optimization for some reason*/            \
+    uint8_t *out = (uint8_t*)dst->array;                                \
+    const int innerloop = 8;                                            \
+    for (size_t i = 0;                                                  \
+        i < BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG);       \
+                                                         i+=innerloop) {\
+        __m256i A1, A2, AO;                                             \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1));                  \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2));                  \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)out, AO);                        \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 32));             \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 32));             \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+32), AO);                   \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 64));             \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 64));             \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+64), AO);                   \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 96));             \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 96));             \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+96), AO);                   \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 128));            \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 128));            \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+128), AO);                  \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 160));            \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 160));            \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+160), AO);                  \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 192));            \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 192));            \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+192), AO);                  \
+        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 224));            \
+        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 224));            \
+        AO = avx_intrinsic(A2, A1);                                     \
+        _mm256_storeu_si256((__m256i *)(out+224), AO);                  \
+        out+=256;                                                       \
+        array_1 += 256;                                                 \
+        array_2 += 256;                                                 \
+    }                                                                   \
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                      \
+    return dst->cardinality;                                            \
+}                                                                       \
+/* next, a version that updates cardinality*/                           \
+int bitset_container_##opname(const bitset_container_t *src_1,          \
+                              const bitset_container_t *src_2,          \
+                              bitset_container_t *dst) {                \
+    const __m256i *array_1 = (const __m256i *) src_1->array;            \
+    const __m256i *array_2 = (const __m256i *) src_2->array;            \
+    __m256i *out = (__m256i *) dst->array;                              \
+    dst->cardinality = avx2_harley_seal_popcount256andstore_##opname(array_2,\
+    		array_1, out,BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
+    return dst->cardinality;                                            \
+}                                                                       \
+/* next, a version that just computes the cardinality*/                 \
+int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
+                              const bitset_container_t *src_2) {        \
+    const __m256i *data1 = (const __m256i *) src_1->array;            \
+    const __m256i *data2 = (const __m256i *) src_2->array;            \
+    return avx2_harley_seal_popcount256_##opname(data2,                \
+    		data1, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
+}
+
+
+
+
+
+/*
+int bitset_container_##opname(const bitset_container_t *src_1,          \
+                              const bitset_container_t *src_2,          \
+                              bitset_container_t *dst) {                \
+    const __m256i *array_1 = (const __m256i *) src_1->array;            \
+    const __m256i *array_2 = (const __m256i *) src_2->array;            \
+    __m256i *out = (__m256i *) dst->array;                              \
+    dst->cardinality = avx2_harley_seal_popcount256andstore_##opname(array_1,\
+    		array_2, out,BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
+    return dst->cardinality;                                            \
+}                                                                       \
+*/
+
+
+/*int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
+                              const bitset_container_t *src_2) {        \
+    const __m256i *data1 = (const __m256i *) src_1->array;            \
+    const __m256i *data2 = (const __m256i *) src_2->array;            \
+    return avx2_harley_seal_popcount256_##opname(data1,                \
+    		data2, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
+}*/
+
+#else /* not USEAVX  */
+
+#define BITSET_CONTAINER_FN(opname, opsymbol, avxintrinsic)               \
+int bitset_container_##opname(const bitset_container_t *src_1,            \
+                              const bitset_container_t *src_2,            \
+                              bitset_container_t *dst) {                  \
+    const uint64_t *array_1 = src_1->array;                               \
+    const uint64_t *array_2 = src_2->array;                               \
+    uint64_t *out = dst->array;                                           \
+    int32_t sum = 0;                                                      \
+    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 2) {      \
+        const uint64_t word_1 = (array_1[i])opsymbol(array_2[i]),         \
+                       word_2 = (array_1[i + 1])opsymbol(array_2[i + 1]); \
+        out[i] = word_1;                                                  \
+        out[i + 1] = word_2;                                              \
+        sum += hamming(word_1);                                    \
+        sum += hamming(word_2);                                    \
+    }                                                                     \
+    dst->cardinality = sum;                                               \
+    return dst->cardinality;                                              \
+}                                                                         \
+int bitset_container_##opname##_nocard(const bitset_container_t *src_1,   \
+                                       const bitset_container_t *src_2,   \
+                                       bitset_container_t *dst) {         \
+    const uint64_t *array_1 = src_1->array, *array_2 = src_2->array;      \
+    uint64_t *out = dst->array;                                           \
+    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i++) {         \
+        out[i] = (array_1[i])opsymbol(array_2[i]);                        \
+    }                                                                     \
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                                                \
+    return dst->cardinality;                                              \
+}                                                                         \
+int bitset_container_##opname##_justcard(const bitset_container_t *src_1,   \
+                              const bitset_container_t *src_2) {          \
+    const uint64_t *array_1 = src_1->array;                               \
+    const uint64_t *array_2 = src_2->array;                               \
+    int32_t sum = 0;                                                      \
+    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 2) {      \
+        const uint64_t word_1 = (array_1[i])opsymbol(array_2[i]),         \
+                       word_2 = (array_1[i + 1])opsymbol(array_2[i + 1]); \
+        sum += hamming(word_1);                                    \
+        sum += hamming(word_2);                                    \
+    }                                                                     \
+    return sum;                                                           \
+}
+
+#endif
+
+// we duplicate the function because other containers use the "or" term, makes API more consistent
+BITSET_CONTAINER_FN(or, |, _mm256_or_si256)
+BITSET_CONTAINER_FN(union, |, _mm256_or_si256)
+
+// we duplicate the function because other containers use the "intersection" term, makes API more consistent
+BITSET_CONTAINER_FN(and, &, _mm256_and_si256)
+BITSET_CONTAINER_FN(intersection, &, _mm256_and_si256)
+
+BITSET_CONTAINER_FN(xor, ^, _mm256_xor_si256)
+BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256)
+// clang-format On
+
+
+
+int bitset_container_to_uint32_array( void *vout, const bitset_container_t *cont, uint32_t base) {
+#ifdef USEAVX2FORDECODING
+	if(cont->cardinality >= 8192)// heuristic
+		return (int) bitset_extract_setbits_avx2(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, vout,cont->cardinality,base);
+	else
+		return (int) bitset_extract_setbits(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, vout,base);
+#else
+	return (int) bitset_extract_setbits(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, vout,base);
+#endif
+}
+
+/*
+ * Print this container using printf (useful for debugging).
+ */
+void bitset_container_printf(const bitset_container_t * v) {
+	printf("{");
+	uint32_t base = 0;
+	bool iamfirst = true;// TODO: rework so that this is not necessary yet still readable
+	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
+		uint64_t w = v->array[i];
+		while (w != 0) {
+			uint64_t t = w & -w;
+			int r = __builtin_ctzll(w);
+			if(iamfirst) {// predicted to be false
+				printf("%d",base + r);
+				iamfirst = false;
+			} else {
+				printf(",%d",base + r);
+			}
+			w ^= t;
+		}
+		base += 64;
+	}
+	printf("}");
+}
+
+
+/*
+ * Print this container using printf as a comma-separated list of 32-bit integers starting at base.
+ */
+void bitset_container_printf_as_uint32_array(const bitset_container_t * v, uint32_t base) {
+	bool iamfirst = true;// TODO: rework so that this is not necessary yet still readable
+	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
+		uint64_t w = v->array[i];
+		while (w != 0) {
+			uint64_t t = w & -w;
+			int r = __builtin_ctzll(w);
+			if(iamfirst) {// predicted to be false
+				printf("%d", r + base);
+				iamfirst = false;
+			} else {
+				printf(",%d",r + base);
+			}
+			w ^= t;
+		}
+		base += 64;
+	}
+}
+
+
+// TODO: use the fast lower bound, also
+int bitset_container_number_of_runs(bitset_container_t *b) {
+  int num_runs = 0;
+  uint64_t next_word = b->array[0];
+
+  for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS-1; ++i) {
+    uint64_t word = next_word;
+    next_word = b->array[i+1];
+    num_runs += hamming((~word) & (word << 1)) + ( (word >> 63) & ~next_word);
+  }
+
+  uint64_t word = next_word;
+  num_runs += hamming((~word) & (word << 1));
+  if((word & 0x8000000000000000ULL) != 0)
+    num_runs++;
+  return num_runs;
+}
+
+int32_t bitset_container_serialize(bitset_container_t *container, char *buf) {
+  int32_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
+  memcpy(buf, container->array, l);
+  return(l);
+}
+
+
+
+int32_t bitset_container_write(const bitset_container_t *container,
+                                  char *buf) {
+	memcpy(buf, container->array, BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t));
+	return bitset_container_size_in_bytes(container);
+}
+
+
+int32_t bitset_container_read(int32_t cardinality, bitset_container_t *container,
+		const char *buf)  {
+	container->cardinality = cardinality;
+	memcpy(container->array, buf, BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t));
+	return bitset_container_size_in_bytes(container);
+}
+
+uint32_t bitset_container_serialization_len() {
+  return(sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
+}
+
+void* bitset_container_deserialize(const char *buf, size_t buf_len) {
+  bitset_container_t *ptr;
+  size_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
+
+  if(l != buf_len)
+    return(NULL);
+
+  if((ptr = (bitset_container_t *)malloc(sizeof(bitset_container_t))) != NULL) {
+    memcpy(ptr, buf, sizeof(bitset_container_t));
+    // sizeof(__m256i) == 32
+    if(posix_memalign((void **)&ptr->array, 32, l)) {
+      free(ptr);
+      return(NULL);
+    }
+
+    memcpy(ptr->array, buf, l);
+    ptr->cardinality = bitset_container_compute_cardinality(ptr);
+  }
+
+  return((void*)ptr);
+}
+
+bool bitset_container_iterate(const bitset_container_t *cont, uint32_t base, roaring_iterator iterator, void *ptr) {
+  for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
+    uint64_t w = cont->array[i];
+    while (w != 0) {
+      uint64_t t = w & -w;
+      int r = __builtin_ctzll(w);
+      if(!iterator(r + base, ptr)) return false;
+      w ^= t;
+    }
+    base += 64;
+  }
+  return true;
+}
+
+
+bool bitset_container_equals(bitset_container_t *container1, bitset_container_t *container2) {
+	if((container1->cardinality != BITSET_UNKNOWN_CARDINALITY) && (container2->cardinality != BITSET_UNKNOWN_CARDINALITY)) {
+		if(container1->cardinality != container2->cardinality) {
+			return false;
+		}
+	}
+	for(int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
+		if(container1->array[i] != container2->array[i]) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool bitset_container_select(const bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
+    int card = bitset_container_cardinality(container);
+    if(rank >= *start_rank + card) {
+        *start_rank += card;
+        return false;
+    }
+    const uint64_t *array = container->array;
+    int32_t size;
+    for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 1) {
+        size = hamming(array[i]);
+        if(rank <= *start_rank + size) {
+            uint64_t w = container->array[i];
+            uint16_t base = i*64;
+            while (w != 0) {
+                uint64_t t = w & -w;
+                int r = __builtin_ctzll(w);
+                if(*start_rank == rank) {
+                    *element = r+base;
+                    return true;
+                }
+                w ^= t;
+                *start_rank += 1;
+            }
+        }
+        else
+            *start_rank += size;
+    }
+    assert(false);
+    __builtin_unreachable();
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/bitset.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_xor.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_xor.c"
+/*
+ * mixed_xor.c
+ */
+
+#include <assert.h>
+#include <string.h>
+
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst (which has no container initially).
+ * Result is true iff dst is a bitset  */
+bool array_bitset_container_xor(const array_container_t *src_1,
+                                const bitset_container_t *src_2, void **dst) {
+    bitset_container_t *result = bitset_container_create();
+    bitset_container_copy(src_2, result);
+    result->cardinality = bitset_flip_list_withcard(
+        result->array, result->cardinality, src_1->array, src_1->cardinality);
+
+    // do required type conversions.
+    if (result->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(result);
+        bitset_container_free(result);
+        return false;  // not bitset
+    }
+    *dst = result;
+    return true;  // bitset
+}
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst. It is allowed for src_2 to be dst.  This version does not
+ * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
+ */
+
+void array_bitset_container_lazy_xor(const array_container_t *src_1,
+                                     const bitset_container_t *src_2,
+                                     bitset_container_t *dst) {
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    bitset_flip_list(dst->array, src_1->array, src_1->cardinality);
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+}
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst. Result may be either a bitset or an array container
+ * (returns "result is bitset"). dst does not initially have
+ * any container, but becomes either a bitset container (return
+ * result true) or an array container.
+ */
+
+bool run_bitset_container_xor(const run_container_t *src_1,
+                              const bitset_container_t *src_2, void **dst) {
+    bitset_container_t *result = bitset_container_create();
+
+    bitset_container_copy(src_2, result);
+    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+        rle16_t rle = src_1->runs[rlepos];
+        bitset_flip_range(result->array, rle.value,
+                          rle.value + rle.length + UINT32_C(1));
+    }
+    result->cardinality = bitset_container_compute_cardinality(result);
+
+    if (result->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(result);
+        bitset_container_free(result);
+        return false;  // not bitset
+    }
+    *dst = result;
+    return true;  // bitset
+}
+
+/* lazy xor.  Dst is initialized and may be equal to src_2.
+ *  Result is left as a bitset container, even if actual
+ *  cardinality would dictate an array container.
+ */
+
+void run_bitset_container_lazy_xor(const run_container_t *src_1,
+                                   const bitset_container_t *src_2,
+                                   bitset_container_t *dst) {
+    if (src_2 != dst) bitset_container_copy(src_2, dst);
+    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+        rle16_t rle = src_1->runs[rlepos];
+        bitset_flip_range(dst->array, rle.value,
+                          rle.value + rle.length + UINT32_C(1));
+    }
+    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any kind of container.
+ */
+
+int array_run_container_xor(const array_container_t *src_1,
+                            const run_container_t *src_2, void **dst) {
+    // semi following Java XOR implementation as of May 2016
+    // the C OR implementation works quite differently and can return a run
+    // container
+    // TODO could optimize for full run containers.
+
+    // use of lazy following Java impl.
+    const int arbitrary_threshold = 32;
+    if (src_1->cardinality < arbitrary_threshold) {
+        run_container_t *ans = run_container_create();
+        array_run_container_lazy_xor(src_1, src_2, ans);  // keeps runs.
+        uint8_t typecode_after;
+        *dst =
+            convert_run_to_efficient_container_and_free(ans, &typecode_after);
+        return typecode_after;
+    }
+
+    int card = run_container_cardinality(src_2);
+    if (card <= DEFAULT_MAX_SIZE) {
+        // Java implementation works with the array, xoring the run elements via
+        // iterator
+        array_container_t *temp = array_container_from_run(src_2);
+        bool ret_is_bitset = array_array_container_xor(temp, src_1, dst);
+        array_container_free(temp);
+        return ret_is_bitset ? BITSET_CONTAINER_TYPE_CODE
+                             : ARRAY_CONTAINER_TYPE_CODE;
+
+    } else {  // guess that it will end up as a bitset
+        bitset_container_t *result = bitset_container_from_run(src_2);
+        bool is_bitset = bitset_array_container_ixor(result, src_1, dst);
+        // any necessary type conversion has been done by the ixor
+        int retval = (is_bitset ? BITSET_CONTAINER_TYPE_CODE
+                                : ARRAY_CONTAINER_TYPE_CODE);
+        return retval;
+    }
+}
+
+/* Dst is a valid run container. (Can it be src_2? Let's say not.)
+ * Leaves result as run container, even if other options are
+ * smaller.
+ */
+
+void array_run_container_lazy_xor(const array_container_t *src_1,
+                                  const run_container_t *src_2,
+                                  run_container_t *dst) {
+    run_container_grow(dst, src_1->cardinality + src_2->n_runs, false);
+    int32_t rlepos = 0;
+    int32_t arraypos = 0;
+    dst->n_runs = 0;
+
+    while ((rlepos < src_2->n_runs) && (arraypos < src_1->cardinality)) {
+        if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
+            run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
+                                                 src_2->runs[rlepos].length);
+            rlepos++;
+        } else {
+            run_container_smart_append_exclusive(dst, src_1->array[arraypos],
+                                                 0);
+            arraypos++;
+        }
+    }
+    while (arraypos < src_1->cardinality) {
+        run_container_smart_append_exclusive(dst, src_1->array[arraypos], 0);
+        arraypos++;
+    }
+    while (rlepos < src_2->n_runs) {
+        run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
+                                             src_2->runs[rlepos].length);
+        rlepos++;
+    }
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any kind of container.
+ */
+
+int run_run_container_xor(const run_container_t *src_1,
+                          const run_container_t *src_2, void **dst) {
+    run_container_t *ans = run_container_create();
+    run_container_xor(src_1, src_2, ans);
+    uint8_t typecode_after;
+    *dst = convert_run_to_efficient_container_and_free(ans, &typecode_after);
+    return typecode_after;
+}
+
+/*
+ * Java implementation (as of May 2016) for array_run, run_run
+ * and  bitset_run don't do anything different for inplace.
+ * Could adopt the mixed_union.c approach instead (ie, using
+ * smart_append_exclusive)
+ *
+ */
+
+bool array_array_container_xor(const array_container_t *src_1,
+                               const array_container_t *src_2, void **dst) {
+    int totalCardinality =
+        src_1->cardinality + src_2->cardinality;  // upper bound
+    if (totalCardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_create_given_capacity(totalCardinality);
+        array_container_xor(src_1, src_2, (array_container_t *)*dst);
+        return false;  // not a bitset
+    }
+    *dst = bitset_container_from_array(src_1);
+    bool returnval = true;  // expect a bitset
+    bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+    ourbitset->cardinality = bitset_flip_list_withcard(
+        ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
+    if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
+        // need to convert!
+        *dst = array_container_from_bitset(ourbitset);
+        bitset_container_free(ourbitset);
+        returnval = false;  // not going to be a bitset
+    }
+
+    return returnval;
+}
+
+bool array_array_container_lazy_xor(const array_container_t *src_1,
+                                    const array_container_t *src_2,
+                                    void **dst) {
+    int totalCardinality = src_1->cardinality + src_2->cardinality;
+    // upper bound, but probably poor estimate for xor
+    if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
+        *dst = array_container_create_given_capacity(totalCardinality);
+        if (*dst != NULL)
+            array_container_xor(src_1, src_2, (array_container_t *)*dst);
+        return false;  // not a bitset
+    }
+    *dst = bitset_container_from_array(src_1);
+    bool returnval = true;  // expect a bitset (maybe, for XOR??)
+    if (*dst != NULL) {
+        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
+        bitset_flip_list(ourbitset->array, src_2->array, src_2->cardinality);
+        ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
+    }
+    return returnval;
+}
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst (which has no container initially). Return value is
+ * "dst is a bitset"
+ */
+
+bool bitset_bitset_container_xor(const bitset_container_t *src_1,
+                                 const bitset_container_t *src_2, void **dst) {
+    bitset_container_t *ans = bitset_container_create();
+    int card = bitset_container_xor(src_1, src_2, ans);
+    if (card <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(ans);
+        bitset_container_free(ans);
+        return false;  // not bitset
+    } else {
+        *dst = ans;
+        return true;
+    }
+}
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst (which has no container initially).  It will modify src_1
+ * to be dst if the result is a bitset.  Otherwise, it will
+ * free src_1 and dst will be a new array container.  In both
+ * cases, the caller is responsible for deallocating dst.
+ * Returns true iff dst is a bitset  */
+
+bool bitset_array_container_ixor(bitset_container_t *src_1,
+                                 const array_container_t *src_2, void **dst) {
+    *dst = src_1;
+    src_1->cardinality = bitset_flip_list_withcard(
+        src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
+
+    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
+        *dst = array_container_from_bitset(src_1);
+        bitset_container_free(src_1);
+        return false;  // not bitset
+    } else
+        return true;
+}
+
+/* a bunch of in-place, some of which may not *really* be inplace.
+ * TODO: write actual inplace routine if efficiency warrants it
+ * Anything inplace with a bitset is a good candidate
+ */
+
+bool bitset_bitset_container_ixor(bitset_container_t *src_1,
+                                  const bitset_container_t *src_2, void **dst) {
+    bool ans = bitset_bitset_container_xor(src_1, src_2, dst);
+    bitset_container_free(src_1);
+    return ans;
+}
+
+bool array_bitset_container_ixor(array_container_t *src_1,
+                                 const bitset_container_t *src_2, void **dst) {
+    bool ans = array_bitset_container_xor(src_1, src_2, dst);
+    array_container_free(src_1);
+    return ans;
+}
+
+/* Compute the xor of src_1 and src_2 and write the result to
+ * dst. Result may be either a bitset or an array container
+ * (returns "result is bitset"). dst does not initially have
+ * any container, but becomes either a bitset container (return
+ * result true) or an array container.
+ */
+
+bool run_bitset_container_ixor(run_container_t *src_1,
+                               const bitset_container_t *src_2, void **dst) {
+    bool ans = run_bitset_container_xor(src_1, src_2, dst);
+    run_container_free(src_1);
+    return ans;
+}
+
+bool bitset_run_container_ixor(bitset_container_t *src_1,
+                               const run_container_t *src_2, void **dst) {
+    bool ans = run_bitset_container_xor(src_2, src_1, dst);
+    bitset_container_free(src_1);
+    return ans;
+}
+
+/* dst does not indicate a valid container initially.  Eventually it
+ * can become any kind of container.
+ */
+
+int array_run_container_ixor(array_container_t *src_1,
+                             const run_container_t *src_2, void **dst) {
+    int ans = array_run_container_xor(src_1, src_2, dst);
+    array_container_free(src_1);
+    return ans;
+}
+
+int run_array_container_ixor(run_container_t *src_1,
+                             const array_container_t *src_2, void **dst) {
+    int ans = array_run_container_xor(src_2, src_1, dst);
+    run_container_free(src_1);
+    return ans;
+}
+
+bool array_array_container_ixor(array_container_t *src_1,
+                                const array_container_t *src_2, void **dst) {
+    bool ans = array_array_container_xor(src_1, src_2, dst);
+    array_container_free(src_1);
+    return ans;
+}
+
+int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
+                           void **dst) {
+    int ans = run_run_container_xor(src_1, src_2, dst);
+    run_container_free(src_1);
+    return ans;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_xor.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_intersection.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_intersection.c"
+/*
+ * mixed_intersection.c
+ *
+ */
+
+
+/* Compute the intersection of src_1 and src_2 and write the result to
+ * dst.  */
+void array_bitset_container_intersection(const array_container_t *src_1,
+                                         const bitset_container_t *src_2,
+                                         array_container_t *dst) {
+    if (dst->capacity < src_1->cardinality)
+        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    int32_t newcard = 0;  // dst could be src_1
+    const int32_t origcard = src_1->cardinality;
+    for (int i = 0; i < origcard; ++i) {
+        // could probably be vectorized
+        uint16_t key = src_1->array[i];
+        // next bit could be branchless
+        if (bitset_container_contains(src_2, key)) {
+            dst->array[newcard++] = key;
+        }
+    }
+    dst->cardinality = newcard;
+}
+
+/* Compute the intersection of src_1 and src_2 and write the result to
+ * dst. It is allowed for dst to be equal to src_1. We assume that dst is a
+ * valid container. */
+void array_run_container_intersection(const array_container_t *src_1,
+                                      const run_container_t *src_2,
+                                      array_container_t *dst) {
+    if (dst->capacity < src_1->cardinality)
+        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
+    if (src_2->n_runs == 0) {
+        return;
+    }
+    int32_t rlepos = 0;
+    int32_t arraypos = 0;
+    rle16_t rle = src_2->runs[rlepos];
+    int32_t newcard = 0;
+    while (arraypos < src_1->cardinality) {
+        const uint16_t arrayval = src_1->array[arraypos];
+        while (rle.value + rle.length <
+               arrayval) {  // this will frequently be false
+            ++rlepos;
+            if (rlepos == src_2->n_runs) {
+                dst->cardinality = newcard;
+                return;  // we are done
+            }
+            rle = src_2->runs[rlepos];
+        }
+        if (rle.value > arrayval) {
+            arraypos = advanceUntil(src_1->array, arraypos, src_1->cardinality,
+                                    rle.value);
+        } else {
+            dst->array[newcard] = arrayval;
+            newcard++;
+            arraypos++;
+        }
+    }
+    dst->cardinality = newcard;
+}
+
+/* Compute the intersection of src_1 and src_2 and write the result to
+ * *dst. If the result is true then the result is a bitset_container_t
+ * otherwise is a array_container_t.  */
+bool run_bitset_container_intersection(const run_container_t *src_1,
+                                       const bitset_container_t *src_2,
+                                       void **dst) {
+    int32_t card = run_container_cardinality(src_1);
+    if (card <= DEFAULT_MAX_SIZE) {
+        // result can only be an array (assuming that we never make a
+        // RunContainer)
+        if (card > src_2->cardinality) {
+            card = src_2->cardinality;
+        }
+        array_container_t *answer = array_container_create_given_capacity(card);
+        *dst = answer;
+        if (*dst == NULL) {
+            return false;
+        }
+        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+            rle16_t rle = src_1->runs[rlepos];
+            uint32_t endofrun = (uint32_t)rle.value + rle.length;
+            for (uint32_t runValue = rle.value; runValue <= endofrun;
+                 ++runValue) {
+                if (bitset_container_contains(src_2, runValue)) {
+                    answer->array[answer->cardinality++] = (uint16_t)runValue;
+                }
+            }
+        }
+        return false;
+    }
+    if (*dst == src_2) {  // we attempt in-place
+        bitset_container_t *answer = (bitset_container_t *)*dst;
+        uint32_t start = 0;
+        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+            const rle16_t rle = src_1->runs[rlepos];
+            uint32_t end = rle.value;
+            bitset_reset_range(src_2->array, start, end);
+
+            start = end + rle.length + 1;
+        }
+        bitset_reset_range(src_2->array, start, UINT32_C(1) << 16);
+        answer->cardinality = bitset_container_compute_cardinality(answer);
+        if (src_2->cardinality > DEFAULT_MAX_SIZE) {
+            return true;
+        } else {
+            array_container_t *newanswer = array_container_from_bitset(src_2);
+            if (newanswer == NULL) {
+                *dst = NULL;
+                return false;
+            }
+            *dst = newanswer;
+            return false;
+        }
+    } else {  // no inplace
+        // we expect the answer to be a bitmap (if we are lucky)
+        bitset_container_t *answer = bitset_container_clone(src_2);
+
+        *dst = answer;
+        if (answer == NULL) {
+            return true;
+        }
+        uint32_t start = 0;
+        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
+            const rle16_t rle = src_1->runs[rlepos];
+            uint32_t end = rle.value;
+            bitset_reset_range(answer->array, start, end);
+            start = end + rle.length + 1;
+        }
+        bitset_reset_range(answer->array, start, UINT32_C(1) << 16);
+        answer->cardinality = bitset_container_compute_cardinality(answer);
+
+        if (answer->cardinality > DEFAULT_MAX_SIZE) {
+            return true;
+        } else {
+            array_container_t *newanswer = array_container_from_bitset(answer);
+            bitset_container_free((bitset_container_t *)*dst);
+            if (newanswer == NULL) {
+                *dst = NULL;
+                return false;
+            }
+            *dst = newanswer;
+            return false;
+        }
+    }
+}
+
+/*
+ * Compute the intersection between src_1 and src_2 and write the result
+ * to *dst. If the return function is true, the result is a bitset_container_t
+ * otherwise is a array_container_t.
+ */
+bool bitset_bitset_container_intersection(const bitset_container_t *src_1,
+                                          const bitset_container_t *src_2,
+                                          void **dst) {
+    const int newCardinality = bitset_container_and_justcard(src_1, src_2);
+    if (newCardinality > DEFAULT_MAX_SIZE) {
+        *dst = bitset_container_create();
+        if (*dst != NULL) {
+            bitset_container_and_nocard(src_1, src_2,
+                                        (bitset_container_t *)*dst);
+            ((bitset_container_t *)*dst)->cardinality = newCardinality;
+        }
+        return true;  // it is a bitset
+    }
+    *dst = array_container_create_given_capacity(newCardinality);
+    if (*dst != NULL) {
+        ((array_container_t *)*dst)->cardinality = newCardinality;
+        bitset_extract_intersection_setbits_uint16(
+            ((bitset_container_t *)src_1)->array,
+            ((bitset_container_t *)src_2)->array,
+            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
+            0);
+    }
+    return false;  // not a bitset
+}
+
+bool bitset_bitset_container_intersection_inplace(
+    bitset_container_t *src_1, const bitset_container_t *src_2, void **dst) {
+    const int newCardinality = bitset_container_and_justcard(src_1, src_2);
+    if (newCardinality > DEFAULT_MAX_SIZE) {
+        *dst = src_1;
+        bitset_container_and_nocard(src_1, src_2, src_1);
+        ((bitset_container_t *)*dst)->cardinality = newCardinality;
+        return true;  // it is a bitset
+    }
+    *dst = array_container_create_given_capacity(newCardinality);
+    if (*dst != NULL) {
+        ((array_container_t *)*dst)->cardinality = newCardinality;
+        bitset_extract_intersection_setbits_uint16(
+            ((bitset_container_t *)src_1)->array,
+            ((bitset_container_t *)src_2)->array,
+            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
+            0);
+    }
+    return false;  // not a bitset
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_intersection.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/run.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/run.c"
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef IS_X64
+#include <x86intrin.h>
+#endif
+
+extern inline int32_t interleavedBinarySearch(const rle16_t *array,
+                                      int32_t lenarray, uint16_t ikey);
+extern inline bool run_container_contains(const run_container_t *run,
+                                           uint16_t pos);
+extern bool run_container_is_full(const run_container_t *run);
+extern bool run_container_nonzero_cardinality(const run_container_t *r);
+extern void run_container_clear(run_container_t *run);
+extern int32_t run_container_serialized_size_in_bytes(int32_t num_runs);
+extern run_container_t *run_container_create_range(uint32_t start,
+                                                   uint32_t stop);
+
+bool run_container_add(run_container_t *run, uint16_t pos) {
+    int32_t index = interleavedBinarySearch(run->runs, run->n_runs, pos);
+    if (index >= 0) return false;  // already there
+    index = -index - 2;            // points to preceding value, possibly -1
+    if (index >= 0) {              // possible match
+        int32_t offset = pos - run->runs[index].value;
+        int32_t le = run->runs[index].length;
+        if (offset <= le) return false;  // already there
+        if (offset == le + 1) {
+            // we may need to fuse
+            if (index + 1 < run->n_runs) {
+                if (run->runs[index + 1].value == pos + 1) {
+                    // indeed fusion is needed
+                    run->runs[index].length = run->runs[index + 1].value +
+                                              run->runs[index + 1].length -
+                                              run->runs[index].value;
+                    recoverRoomAtIndex(run, index + 1);
+                    return true;
+                }
+            }
+            run->runs[index].length++;
+            return true;
+        }
+        if (index + 1 < run->n_runs) {
+            // we may need to fuse
+            if (run->runs[index + 1].value == pos + 1) {
+                // indeed fusion is needed
+                run->runs[index + 1].value = pos;
+                run->runs[index + 1].length = run->runs[index + 1].length + 1;
+                return true;
+            }
+        }
+    }
+    if (index == -1) {
+        // we may need to extend the first run
+        if (0 < run->n_runs) {
+            if (run->runs[0].value == pos + 1) {
+                run->runs[0].length++;
+                run->runs[0].value--;
+                return true;
+            }
+        }
+    }
+    makeRoomAtIndex(run, index + 1);
+    run->runs[index + 1].value = pos;
+    run->runs[index + 1].length = 0;
+    return true;
+}
+
+/* Create a new run container. Return NULL in case of failure. */
+run_container_t *run_container_create_given_capacity(int32_t size) {
+    run_container_t *run;
+    /* Allocate the run container itself. */
+    if ((run = (run_container_t *)malloc(sizeof(run_container_t))) == NULL) {
+        return NULL;
+    }
+    if ((run->runs = (rle16_t *)malloc(sizeof(rle16_t) * size)) == NULL) {
+        free(run);
+        return NULL;
+    }
+    run->capacity = size;
+    run->n_runs = 0;
+    return run;
+}
+
+/* Create a new run container. Return NULL in case of failure. */
+run_container_t *run_container_create(void) {
+    return run_container_create_given_capacity(RUN_DEFAULT_INIT_SIZE);
+}
+
+run_container_t *run_container_clone(const run_container_t *src) {
+    run_container_t *run = run_container_create_given_capacity(src->capacity);
+    if (run == NULL) return NULL;
+    run->capacity = src->capacity;
+    run->n_runs = src->n_runs;
+    memcpy(run->runs, src->runs, src->n_runs * sizeof(rle16_t));
+    return run;
+}
+
+/* Free memory. */
+void run_container_free(run_container_t *run) {
+    free(run->runs);
+    run->runs = NULL;  // pedantic
+    free(run);
+}
+
+#ifdef USEAVX
+
+/* Get the cardinality of `run'. Requires an actual computation. */
+int run_container_cardinality(const run_container_t *run) {
+    const int32_t n_runs = run->n_runs;
+    const rle16_t *runs = run->runs;
+
+    /* by initializing with n_runs, we omit counting the +1 for each pair. */
+    int sum = n_runs;
+    int32_t k = 0;
+    const int32_t step = sizeof(__m256i) / sizeof(rle16_t);
+    if (n_runs > step) {
+        __m256i total = _mm256_setzero_si256();
+        for (; k + step <= n_runs; k += step) {
+            __m256i ymm1 = _mm256_lddqu_si256((const __m256i *)(runs + k));
+            __m256i justlengths = _mm256_srli_epi32(ymm1, 16);
+            total = _mm256_add_epi32(total, justlengths);
+        }
+        // a store might be faster than extract?
+        uint32_t buffer[sizeof(__m256i) / sizeof(rle16_t)];
+        _mm256_store_si256((__m256i *)buffer, total);
+        sum += (buffer[0] + buffer[1]) + (buffer[2] + buffer[3]) +
+               (buffer[4] + buffer[5]) + (buffer[6] + buffer[7]);
+    }
+    for (; k < n_runs; ++k) {
+        sum += runs[k].length;
+    }
+
+    return sum;
+}
+
+#else
+
+/* Get the cardinality of `run'. Requires an actual computation. */
+int run_container_cardinality(const run_container_t *run) {
+    const int32_t n_runs = run->n_runs;
+    const rle16_t *runs = run->runs;
+
+    /* by initializing with n_runs, we omit counting the +1 for each pair. */
+    int sum = n_runs;
+    for (int k = 0; k < n_runs; ++k) {
+        sum += runs[k].length;
+    }
+
+    return sum;
+}
+#endif
+
+void run_container_grow(run_container_t *run, int32_t min, bool copy) {
+    int32_t newCapacity =
+        (run->capacity == 0)
+            ? RUN_DEFAULT_INIT_SIZE
+            : run->capacity < 64 ? run->capacity * 2
+                                 : run->capacity < 1024 ? run->capacity * 3 / 2
+                                                        : run->capacity * 5 / 4;
+    if (newCapacity < min) newCapacity = min;
+    run->capacity = newCapacity;
+    assert(run->capacity >= min);
+    if (copy) {
+        rle16_t *oldruns = run->runs;
+        run->runs =
+            (rle16_t *)realloc(oldruns, run->capacity * sizeof(rle16_t));
+        if (run->runs == NULL) free(oldruns);
+    } else {
+        free(run->runs);
+        run->runs = (rle16_t *)malloc(run->capacity * sizeof(rle16_t));
+    }
+    // TODO: handle the case where realloc fails
+    assert(run->runs != NULL);
+}
+
+/* copy one container into another */
+void run_container_copy(const run_container_t *src, run_container_t *dst) {
+    const int32_t n_runs = src->n_runs;
+    if (src->n_runs > dst->capacity) {
+        run_container_grow(dst, n_runs, false);
+    }
+    dst->n_runs = n_runs;
+    memcpy(dst->runs, src->runs, sizeof(rle16_t) * n_runs);
+}
+
+/* Compute the union of `src_1' and `src_2' and write the result to `dst'
+ * It is assumed that `dst' is distinct from both `src_1' and `src_2'. */
+void run_container_union(const run_container_t *src_1,
+                         const run_container_t *src_2, run_container_t *dst) {
+    // TODO: this could be a lot more efficient
+
+    // we start out with inexpensive checks
+    const bool if1 = run_container_is_full(src_1);
+    const bool if2 = run_container_is_full(src_2);
+    if (if1 || if2) {
+        if (if1) {
+            run_container_copy(src_1, dst);
+            return;
+        }
+        if (if2) {
+            run_container_copy(src_2, dst);
+            return;
+        }
+    }
+    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
+    if (dst->capacity < neededcapacity)
+        run_container_grow(dst, neededcapacity, false);
+    dst->n_runs = 0;
+    int32_t rlepos = 0;
+    int32_t xrlepos = 0;
+
+    rle16_t previousrle;
+    if (src_1->runs[rlepos].value <= src_2->runs[xrlepos].value) {
+        previousrle = run_container_append_first(dst, src_1->runs[rlepos]);
+        rlepos++;
+    } else {
+        previousrle = run_container_append_first(dst, src_2->runs[xrlepos]);
+        xrlepos++;
+    }
+
+    while ((xrlepos < src_2->n_runs) && (rlepos < src_1->n_runs)) {
+        rle16_t newrl;
+        if (src_1->runs[rlepos].value <= src_2->runs[xrlepos].value) {
+            newrl = src_1->runs[rlepos];
+            rlepos++;
+        } else {
+            newrl = src_2->runs[xrlepos];
+            xrlepos++;
+        }
+        run_container_append(dst, newrl, &previousrle);
+    }
+    while (xrlepos < src_2->n_runs) {
+        run_container_append(dst, src_2->runs[xrlepos], &previousrle);
+        xrlepos++;
+    }
+    while (rlepos < src_1->n_runs) {
+        run_container_append(dst, src_1->runs[rlepos], &previousrle);
+        rlepos++;
+    }
+}
+
+/* Compute the union of `src_1' and `src_2' and write the result to `src_1'
+ */
+void run_container_union_inplace(run_container_t *src_1,
+                                 const run_container_t *src_2) {
+    // TODO: this could be a lot more efficient
+
+    // we start out with inexpensive checks
+    const bool if1 = run_container_is_full(src_1);
+    const bool if2 = run_container_is_full(src_2);
+    if (if1 || if2) {
+        if (if1) {
+            return;
+        }
+        if (if2) {
+            run_container_copy(src_2, src_1);
+            return;
+        }
+    }
+    // we move the data to the end of the current array
+    const int32_t maxoutput = src_1->n_runs + src_2->n_runs;
+    const int32_t neededcapacity = maxoutput + src_1->n_runs;
+    if (src_1->capacity < neededcapacity)
+        run_container_grow(src_1, neededcapacity, true);
+    memmove(src_1->runs + maxoutput, src_1->runs,
+            src_1->n_runs * sizeof(rle16_t));
+    rle16_t *inputsrc1 = src_1->runs + maxoutput;
+    const int32_t input1nruns = src_1->n_runs;
+    src_1->n_runs = 0;
+    int32_t rlepos = 0;
+    int32_t xrlepos = 0;
+
+    rle16_t previousrle;
+    if (inputsrc1[rlepos].value <= src_2->runs[xrlepos].value) {
+        previousrle = run_container_append_first(src_1, inputsrc1[rlepos]);
+        rlepos++;
+    } else {
+        previousrle = run_container_append_first(src_1, src_2->runs[xrlepos]);
+        xrlepos++;
+    }
+    while ((xrlepos < src_2->n_runs) && (rlepos < input1nruns)) {
+        rle16_t newrl;
+        if (inputsrc1[rlepos].value <= src_2->runs[xrlepos].value) {
+            newrl = inputsrc1[rlepos];
+            rlepos++;
+        } else {
+            newrl = src_2->runs[xrlepos];
+            xrlepos++;
+        }
+        run_container_append(src_1, newrl, &previousrle);
+    }
+    while (xrlepos < src_2->n_runs) {
+        run_container_append(src_1, src_2->runs[xrlepos], &previousrle);
+        xrlepos++;
+    }
+    while (rlepos < input1nruns) {
+        run_container_append(src_1, inputsrc1[rlepos], &previousrle);
+        rlepos++;
+    }
+}
+
+/* Compute the symmetric difference of `src_1' and `src_2' and write the result
+ * to `dst'
+ * It is assumed that `dst' is distinct from both `src_1' and `src_2'. */
+void run_container_xor(const run_container_t *src_1,
+                       const run_container_t *src_2, run_container_t *dst) {
+    // don't bother to convert xor with full range into negation
+    // since negation is implemented similarly
+
+    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
+    if (dst->capacity < neededcapacity)
+        run_container_grow(dst, neededcapacity, false);
+
+    int32_t pos1 = 0;
+    int32_t pos2 = 0;
+    dst->n_runs = 0;
+
+    while ((pos1 < src_1->n_runs) && (pos2 < src_2->n_runs)) {
+        if (src_1->runs[pos1].value <= src_2->runs[pos2].value) {
+            run_container_smart_append_exclusive(dst, src_1->runs[pos1].value,
+                                                 src_1->runs[pos1].length);
+            pos1++;
+        } else {
+            run_container_smart_append_exclusive(dst, src_2->runs[pos2].value,
+                                                 src_2->runs[pos2].length);
+            pos2++;
+        }
+    }
+    while (pos1 < src_1->n_runs) {
+        run_container_smart_append_exclusive(dst, src_1->runs[pos1].value,
+                                             src_1->runs[pos1].length);
+        pos1++;
+    }
+
+    while (pos2 < src_2->n_runs) {
+        run_container_smart_append_exclusive(dst, src_2->runs[pos2].value,
+                                             src_2->runs[pos2].length);
+        pos2++;
+    }
+}
+
+/* Compute the intersection of src_1 and src_2 and write the result to
+ * dst. It is assumed that dst is distinct from both src_1 and src_2. */
+void run_container_intersection(const run_container_t *src_1,
+                                const run_container_t *src_2,
+                                run_container_t *dst) {
+    const bool if1 = run_container_is_full(src_1);
+    const bool if2 = run_container_is_full(src_2);
+    if (if1 || if2) {
+        if (if1) {
+            run_container_copy(src_2, dst);
+            return;
+        }
+        if (if2) {
+            run_container_copy(src_1, dst);
+            return;
+        }
+    }
+    // TODO: this could be a lot more efficient, could use SIMD optimizations
+    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
+    if (dst->capacity < neededcapacity)
+        run_container_grow(dst, neededcapacity, false);
+    dst->n_runs = 0;
+    int32_t rlepos = 0;
+    int32_t xrlepos = 0;
+    int32_t start = src_1->runs[rlepos].value;
+    int32_t end = start + src_1->runs[rlepos].length + 1;
+    int32_t xstart = src_2->runs[xrlepos].value;
+    int32_t xend = xstart + src_2->runs[xrlepos].length + 1;
+    while ((rlepos < src_1->n_runs) && (xrlepos < src_2->n_runs)) {
+        if (end <= xstart) {
+            ++rlepos;
+            if (rlepos < src_1->n_runs) {
+                start = src_1->runs[rlepos].value;
+                end = start + src_1->runs[rlepos].length + 1;
+            }
+        } else if (xend <= start) {
+            ++xrlepos;
+            if (xrlepos < src_2->n_runs) {
+                xstart = src_2->runs[xrlepos].value;
+                xend = xstart + src_2->runs[xrlepos].length + 1;
+            }
+        } else {  // they overlap
+            const int32_t lateststart = start > xstart ? start : xstart;
+            int32_t earliestend;
+            if (end == xend) {  // improbable
+                earliestend = end;
+                rlepos++;
+                xrlepos++;
+                if (rlepos < src_1->n_runs) {
+                    start = src_1->runs[rlepos].value;
+                    end = start + src_1->runs[rlepos].length + 1;
+                }
+                if (xrlepos < src_2->n_runs) {
+                    xstart = src_2->runs[xrlepos].value;
+                    xend = xstart + src_2->runs[xrlepos].length + 1;
+                }
+            } else if (end < xend) {
+                earliestend = end;
+                rlepos++;
+                if (rlepos < src_1->n_runs) {
+                    start = src_1->runs[rlepos].value;
+                    end = start + src_1->runs[rlepos].length + 1;
+                }
+
+            } else {  // end > xend
+                earliestend = xend;
+                xrlepos++;
+                if (xrlepos < src_2->n_runs) {
+                    xstart = src_2->runs[xrlepos].value;
+                    xend = xstart + src_2->runs[xrlepos].length + 1;
+                }
+            }
+            dst->runs[dst->n_runs].value = lateststart;
+            dst->runs[dst->n_runs].length = (earliestend - lateststart - 1);
+            dst->n_runs++;
+        }
+    }
+}
+
+/* Compute the difference of src_1 and src_2 and write the result to
+ * dst. It is assumed that dst is distinct from both src_1 and src_2. */
+void run_container_andnot(const run_container_t *src_1,
+                          const run_container_t *src_2, run_container_t *dst) {
+    // following Java implementation as of June 2016
+
+    if (dst->capacity < src_1->n_runs + src_2->n_runs)
+        run_container_grow(dst, src_1->n_runs + src_2->n_runs, false);
+
+    dst->n_runs = 0;
+
+    int rlepos1 = 0;
+    int rlepos2 = 0;
+    int32_t start = src_1->runs[rlepos1].value;
+    int32_t end = start + src_1->runs[rlepos1].length + 1;
+    int32_t start2 = src_2->runs[rlepos2].value;
+    int32_t end2 = start2 + src_2->runs[rlepos2].length + 1;
+
+    while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
+        if (end <= start2) {
+            // output the first run
+            dst->runs[dst->n_runs++] =
+                (rle16_t){.value = (uint16_t)start,
+                          .length = (uint16_t)(end - start - 1)};
+            rlepos1++;
+            if (rlepos1 < src_1->n_runs) {
+                start = src_1->runs[rlepos1].value;
+                end = start + src_1->runs[rlepos1].length + 1;
+            }
+        } else if (end2 <= start) {
+            // exit the second run
+            rlepos2++;
+            if (rlepos2 < src_2->n_runs) {
+                start2 = src_2->runs[rlepos2].value;
+                end2 = start2 + src_2->runs[rlepos2].length + 1;
+            }
+        } else {
+            if (start < start2) {
+                dst->runs[dst->n_runs++] =
+                    (rle16_t){.value = (uint16_t)start,
+                              .length = (uint16_t)(start2 - start - 1)};
+            }
+            if (end2 < end) {
+                start = end2;
+            } else {
+                rlepos1++;
+                if (rlepos1 < src_1->n_runs) {
+                    start = src_1->runs[rlepos1].value;
+                    end = start + src_1->runs[rlepos1].length + 1;
+                }
+            }
+        }
+    }
+    if (rlepos1 < src_1->n_runs) {
+        dst->runs[dst->n_runs++] = (rle16_t){
+            .value = (uint16_t)start, .length = (uint16_t)(end - start - 1)};
+        rlepos1++;
+        if (rlepos1 < src_1->n_runs) {
+            memcpy(dst->runs + dst->n_runs, src_1->runs + rlepos1,
+                   sizeof(rle16_t) * (src_1->n_runs - rlepos1));
+            dst->n_runs += src_1->n_runs - rlepos1;
+        }
+    }
+}
+
+int run_container_to_uint32_array(void *vout, const run_container_t *cont,
+                                  uint32_t base) {
+    int outpos = 0;
+    uint32_t * out = (uint32_t *) vout;
+    for (int i = 0; i < cont->n_runs; ++i) {
+        uint32_t run_start = base + cont->runs[i].value;
+        uint16_t le = cont->runs[i].length;
+        for (int j = 0; j <= le; ++j) {
+          uint32_t val = run_start + j;
+          memcpy(out + outpos, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
+          outpos++;
+        }
+    }
+    return outpos;
+}
+
+/*
+ * Print this container using printf (useful for debugging).
+ */
+void run_container_printf(const run_container_t *cont) {
+    for (int i = 0; i < cont->n_runs; ++i) {
+        uint16_t run_start = cont->runs[i].value;
+        uint16_t le = cont->runs[i].length;
+        printf("[%d,%d]", run_start, run_start + le);
+    }
+}
+
+/*
+ * Print this container using printf as a comma-separated list of 32-bit
+ * integers starting at base.
+ */
+void run_container_printf_as_uint32_array(const run_container_t *cont,
+                                          uint32_t base) {
+    if (cont->n_runs == 0) return;
+    {
+        uint32_t run_start = base + cont->runs[0].value;
+        uint16_t le = cont->runs[0].length;
+        printf("%d", run_start);
+        for (uint32_t j = 1; j <= le; ++j) printf(",%d", run_start + j);
+    }
+    for (int32_t i = 1; i < cont->n_runs; ++i) {
+        uint32_t run_start = base + cont->runs[i].value;
+        uint16_t le = cont->runs[i].length;
+        for (uint32_t j = 0; j <= le; ++j) printf(",%d", run_start + j);
+    }
+}
+
+int32_t run_container_serialize(run_container_t *container, char *buf) {
+    int32_t l, off;
+
+    memcpy(buf, &container->n_runs, off = sizeof(container->n_runs));
+    memcpy(&buf[off], &container->capacity, sizeof(container->capacity));
+    off += sizeof(container->capacity);
+
+    l = sizeof(rle16_t) * container->n_runs;
+    memcpy(&buf[off], container->runs, l);
+    return (off + l);
+}
+
+int32_t run_container_write(const run_container_t *container, char *buf) {
+    memcpy(buf, &container->n_runs, sizeof(uint16_t));
+    memcpy(buf + sizeof(uint16_t), container->runs,
+               container->n_runs * sizeof(rle16_t));
+    return run_container_size_in_bytes(container);
+}
+
+int32_t run_container_read(int32_t cardinality, run_container_t *container,
+                           const char *buf) {
+    (void)cardinality;
+    memcpy(&container->n_runs, buf, sizeof(uint16_t));
+    if (container->n_runs > container->capacity)
+        run_container_grow(container, container->n_runs, false);
+    memcpy(container->runs, buf + sizeof(uint16_t),
+           container->n_runs * sizeof(rle16_t));
+    return run_container_size_in_bytes(container);
+}
+
+uint32_t run_container_serialization_len(run_container_t *container) {
+    return (sizeof(container->n_runs) + sizeof(container->capacity) +
+            sizeof(rle16_t) * container->n_runs);
+}
+
+void *run_container_deserialize(const char *buf, size_t buf_len) {
+    run_container_t *ptr;
+
+    if (buf_len < 8 /* n_runs + capacity */)
+        return (NULL);
+    else
+        buf_len -= 8;
+
+    if ((ptr = (run_container_t *)malloc(sizeof(run_container_t))) != NULL) {
+        size_t len;
+        int32_t off;
+
+        memcpy(&ptr->n_runs, buf, off = 4);
+        memcpy(&ptr->capacity, &buf[off], 4);
+        off += 4;
+
+        len = sizeof(rle16_t) * ptr->n_runs;
+
+        if (len != buf_len) {
+            free(ptr);
+            return (NULL);
+        }
+
+        if ((ptr->runs = (rle16_t *)malloc(len)) == NULL) {
+            free(ptr);
+            return (NULL);
+        }
+
+        memcpy(ptr->runs, &buf[off], len);
+
+        /* Check if returned values are monotonically increasing */
+        for (int32_t i = 0, j = 0; i < ptr->n_runs; i++) {
+            if (ptr->runs[i].value < j) {
+                free(ptr->runs);
+                free(ptr);
+                return (NULL);
+            } else
+                j = ptr->runs[i].value;
+        }
+    }
+
+    return (ptr);
+}
+
+bool run_container_iterate(const run_container_t *cont, uint32_t base,
+                           roaring_iterator iterator, void *ptr) {
+    for (int i = 0; i < cont->n_runs; ++i) {
+        uint32_t run_start = base + cont->runs[i].value;
+        uint16_t le = cont->runs[i].length;
+
+        for (int j = 0; j <= le; ++j)
+            if (!iterator(run_start + j, ptr)) return false;
+    }
+    return true;
+}
+
+bool run_container_equals(run_container_t *container1,
+                          run_container_t *container2) {
+    if (container1->n_runs != container2->n_runs) {
+        return false;
+    }
+    for (int32_t i = 0; i < container1->n_runs; ++i) {
+        if ((container1->runs[i].value != container2->runs[i].value) ||
+            (container1->runs[i].length != container2->runs[i].length))
+            return false;
+    }
+    return true;
+}
+
+// TODO: write smart_append_exclusive version to match the overloaded 1 param
+// Java version (or  is it even used?)
+
+// follows the Java implementation closely
+// length is the rle-value.  Ie, run [10,12) uses a length value 1.
+void run_container_smart_append_exclusive(run_container_t *src,
+                                          const uint16_t start,
+                                          const uint16_t length) {
+    int old_end;
+    rle16_t *last_run = src->n_runs ? src->runs + (src->n_runs - 1) : NULL;
+    rle16_t *appended_last_run = src->runs + src->n_runs;
+
+    if (!src->n_runs ||
+        (start > (old_end = last_run->value + last_run->length + 1))) {
+        *appended_last_run = (rle16_t){.value = start, .length = length};
+        src->n_runs++;
+        return;
+    }
+    if (old_end == start) {
+        // we merge
+        last_run->length += (length + 1);
+        return;
+    }
+    int new_end = start + length + 1;
+
+    if (start == last_run->value) {
+        // wipe out previous
+        if (new_end < old_end) {
+            *last_run = (rle16_t){.value = (uint16_t)new_end,
+                                  .length = (uint16_t)(old_end - new_end - 1)};
+            return;
+        } else if (new_end > old_end) {
+            *last_run = (rle16_t){.value = (uint16_t)old_end,
+                                  .length = (uint16_t)(new_end - old_end - 1)};
+            return;
+        } else {
+            src->n_runs--;
+            return;
+        }
+    }
+    last_run->length = start - last_run->value - 1;
+    if (new_end < old_end) {
+        *appended_last_run =
+            (rle16_t){.value = (uint16_t)new_end,
+                      .length = (uint16_t)(old_end - new_end - 1)};
+        src->n_runs++;
+    } else if (new_end > old_end) {
+        *appended_last_run =
+            (rle16_t){.value = (uint16_t)old_end,
+                      .length = (uint16_t)(new_end - old_end - 1)};
+        src->n_runs++;
+    }
+}
+
+bool run_container_select(const run_container_t *container,
+                          uint32_t *start_rank, uint32_t rank,
+                          uint32_t *element) {
+    for (int i = 0; i < container->n_runs; i++) {
+        uint16_t length = container->runs[i].length;
+        if (rank <= *start_rank + length) {
+            uint16_t value = container->runs[i].value;
+            *element = value + rank - (*start_rank);
+            return true;
+        } else
+            *start_rank += length + 1;
+    }
+    return false;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/run.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_equal.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/containers/mixed_equal.c"
+
+bool array_container_equal_bitset(array_container_t* container1,
+                                  bitset_container_t* container2) {
+    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
+        if (container2->cardinality != container1->cardinality) {
+            return false;
+        }
+    }
+    int32_t pos = 0;
+    for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
+        uint64_t w = container2->array[i];
+        while (w != 0) {
+            uint64_t t = w & -w;
+            uint16_t r = i * 64 + __builtin_ctzll(w);
+            if (pos >= container1->cardinality) {
+                return false;
+            }
+            if (container1->array[pos] != r) {
+                return false;
+            }
+            ++pos;
+            w ^= t;
+        }
+    }
+    return (pos == container1->cardinality);
+}
+
+bool run_container_equals_array(run_container_t* container1,
+                                array_container_t* container2) {
+    if (run_container_cardinality(container1) != container2->cardinality)
+        return false;
+    int32_t pos = 0;
+    for (int i = 0; i < container1->n_runs; ++i) {
+        uint32_t run_start = container1->runs[i].value;
+        uint32_t le = container1->runs[i].length;
+
+        for (uint32_t j = run_start; j <= run_start + le; ++j) {
+            if (pos >= container2->cardinality) {
+                return false;
+            }
+            if (container2->array[pos] != j) {
+                return false;
+            }
+            ++pos;
+        }
+    }
+    return (pos == container2->cardinality);
+}
+
+bool run_container_equals_bitset(run_container_t* container1,
+                                 bitset_container_t* container2) {
+    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
+        if (container2->cardinality != run_container_cardinality(container1)) {
+            return false;
+        }
+    } else {
+        int32_t card = bitset_container_compute_cardinality(
+            container2);  // modify container2?
+        if (card != run_container_cardinality(container1)) {
+            return false;
+        }
+    }
+    for (int i = 0; i < container1->n_runs; ++i) {
+        uint32_t run_start = container1->runs[i].value;
+        uint32_t le = container1->runs[i].length;
+        for (uint32_t j = run_start; j <= run_start + le; ++j) {
+            // todo: this code could be much faster
+            if (!bitset_container_contains(container2, j)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/containers/mixed_equal.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/array_util.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/array_util.c"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -1209,9 +5128,247 @@ size_t union_uint32_card(const uint32_t *set_1, size_t size_1,
     }
     return pos;
 }
-/* end file /Users/saulius/repos/CRoaring/src/array_util.c */
-/* begin file /Users/saulius/repos/CRoaring/src/bitset_util.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/bitset_util.c"
+/* end file /home/dlemire/CVS/github/CRoaring/src/array_util.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/roaring_priority_queue.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/roaring_priority_queue.c"
+
+struct roaring_pq_element_s {
+    uint64_t size;
+    bool is_temporary;
+    roaring_bitmap_t *bitmap;
+};
+
+typedef struct roaring_pq_element_s roaring_pq_element_t;
+
+struct roaring_pq_s {
+    roaring_pq_element_t *elements;
+    uint64_t size;
+};
+
+typedef struct roaring_pq_s roaring_pq_t;
+
+static inline bool compare(roaring_pq_element_t *t1, roaring_pq_element_t *t2) {
+    return t1->size < t2->size;
+}
+
+static void pq_add(roaring_pq_t *pq, roaring_pq_element_t *t) {
+    uint64_t i = pq->size;
+    pq->elements[pq->size++] = *t;
+    while (i > 0) {
+        uint64_t p = (i - 1) >> 1;
+        roaring_pq_element_t ap = pq->elements[p];
+        if (!compare(t, &ap)) break;
+        pq->elements[i] = ap;
+        i = p;
+    }
+    pq->elements[i] = *t;
+}
+
+static void pq_free(roaring_pq_t *pq) {
+    free(pq->elements);
+    pq->elements = NULL;  // paranoid
+    free(pq);
+}
+
+static void percolate_down(roaring_pq_t *pq, uint32_t i) {
+    uint32_t size = pq->size;
+    uint32_t hsize = size >> 1;
+    roaring_pq_element_t ai = pq->elements[i];
+    while (i < hsize) {
+        uint32_t l = (i << 1) + 1;
+        uint32_t r = l + 1;
+        roaring_pq_element_t bestc = pq->elements[l];
+        if (r < size) {
+            if (compare(pq->elements + r, &bestc)) {
+                l = r;
+                bestc = pq->elements[r];
+            }
+        }
+        if (!compare(&bestc, &ai)) {
+            break;
+        }
+        pq->elements[i] = bestc;
+        i = l;
+    }
+    pq->elements[i] = ai;
+}
+
+static roaring_pq_t *create_pq(const roaring_bitmap_t **arr, uint32_t length) {
+    roaring_pq_t *answer = (roaring_pq_t *)malloc(sizeof(roaring_pq_t));
+    answer->elements =
+        (roaring_pq_element_t *)malloc(sizeof(roaring_pq_element_t) * length);
+    answer->size = length;
+    for (uint32_t i = 0; i < length; i++) {
+        answer->elements[i].bitmap = (roaring_bitmap_t *)arr[i];
+        answer->elements[i].is_temporary = false;
+        answer->elements[i].size =
+            roaring_bitmap_portable_size_in_bytes(arr[i]);
+    }
+    for (int32_t i = (length >> 1); i >= 0; i--) {
+        percolate_down(answer, i);
+    }
+    return answer;
+}
+
+static roaring_pq_element_t pq_poll(roaring_pq_t *pq) {
+    roaring_pq_element_t ans = *pq->elements;
+    if (pq->size > 1) {
+        pq->elements[0] = pq->elements[--pq->size];
+        percolate_down(pq, 0);
+    } else
+        --pq->size;
+    // memmove(pq->elements,pq->elements+1,(pq->size-1)*sizeof(roaring_pq_element_t));--pq->size;
+    return ans;
+}
+
+// this function consumes and frees the inputs
+static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
+                                                  roaring_bitmap_t *x2) {
+    uint8_t container_result_type = 0;
+    roaring_bitmap_t *answer = roaring_bitmap_create();
+    const int length1 = ra_get_size(& x1->high_low_container),
+              length2 = ra_get_size(& x2->high_low_container);
+    if (0 == length1) {
+        roaring_bitmap_free(x1);
+        return x2;
+    }
+    if (0 == length2) {
+        roaring_bitmap_free(x2);
+        return x1;
+    }
+    int pos1 = 0, pos2 = 0;
+    uint8_t container_type_1, container_type_2;
+    uint16_t s1 = ra_get_key_at_index( & x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index( & x2->high_low_container, pos2);
+    while (true) {
+        if (s1 == s2) {
+            // todo: unsharing can be inefficient as it may create a clone where
+            // none
+            // is needed, but it has the benefit of being easy to reason about.
+            ra_unshare_container_at_index( & x1->high_low_container, pos1);
+            void *c1 = ra_get_container_at_index( & x1->high_low_container, pos1,
+                                                 &container_type_1);
+            assert(container_type_1 != SHARED_CONTAINER_TYPE_CODE);
+            ra_unshare_container_at_index( & x2->high_low_container, pos2);
+            void *c2 = ra_get_container_at_index( & x2->high_low_container, pos2,
+                                                 &container_type_2);
+            assert(container_type_2 != SHARED_CONTAINER_TYPE_CODE);
+            void *c;
+
+            if ((container_type_2 == BITSET_CONTAINER_TYPE_CODE) &&
+                (container_type_2 != BITSET_CONTAINER_TYPE_CODE)) {
+                c = container_lazy_ior(c2, container_type_2, c1,
+                                       container_type_1,
+                                       &container_result_type);
+                container_free(c1, container_type_1);
+                if (c != c2) {
+                    container_free(c2, container_type_2);
+                }
+            } else {
+                c = container_lazy_ior(c1, container_type_1, c2,
+                                       container_type_2,
+                                       &container_result_type);
+                container_free(c2, container_type_2);
+                if (c != c1) {
+                    container_free(c1, container_type_1);
+                }
+            }
+            // since we assume that the initial containers are non-empty, the
+            // result here
+            // can only be non-empty
+            ra_append( & answer->high_low_container, s1, c, container_result_type);
+            ++pos1;
+            ++pos2;
+            if (pos1 == length1) break;
+            if (pos2 == length2) break;
+            s1 = ra_get_key_at_index( & x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index( & x2->high_low_container, pos2);
+
+        } else if (s1 < s2) {  // s1 < s2
+            void *c1 = ra_get_container_at_index( & x1->high_low_container, pos1,
+                                                 &container_type_1);
+            ra_append( & answer->high_low_container, s1, c1, container_type_1);
+            pos1++;
+            if (pos1 == length1) break;
+            s1 = ra_get_key_at_index( & x1->high_low_container, pos1);
+
+        } else {  // s1 > s2
+            void *c2 = ra_get_container_at_index( & x2->high_low_container, pos2,
+                                                 &container_type_2);
+            ra_append( & answer->high_low_container, s2, c2, container_type_2);
+            pos2++;
+            if (pos2 == length2) break;
+            s2 = ra_get_key_at_index( & x2->high_low_container, pos2);
+        }
+    }
+    if (pos1 == length1) {
+        ra_append_move_range( & answer->high_low_container, & x2->high_low_container,
+                             pos2, length2);
+    } else if (pos2 == length2) {
+        ra_append_move_range( & answer->high_low_container, & x1->high_low_container,
+                             pos1, length1);
+    }
+    ra_clear_without_containers( & x1->high_low_container);
+    ra_clear_without_containers( & x2->high_low_container);
+    free(x1);
+    free(x2);
+    return answer;
+}
+
+/**
+ * Compute the union of 'number' bitmaps using a heap. This can
+ * sometimes be faster than roaring_bitmap_or_many which uses
+ * a naive algorithm. Caller is responsible for freeing the
+ * result.
+ */
+roaring_bitmap_t *roaring_bitmap_or_many_heap(uint32_t number,
+                                              const roaring_bitmap_t **x) {
+    if (number == 0) {
+        return roaring_bitmap_create();
+    }
+    if (number == 1) {
+        return roaring_bitmap_copy(x[0]);
+    }
+    roaring_pq_t *pq = create_pq(x, number);
+    while (pq->size > 1) {
+        roaring_pq_element_t x1 = pq_poll(pq);
+        roaring_pq_element_t x2 = pq_poll(pq);
+
+        if (x1.is_temporary && x2.is_temporary) {
+            roaring_bitmap_t *newb =
+                lazy_or_from_lazy_inputs(x1.bitmap, x2.bitmap);
+            uint64_t bsize = roaring_bitmap_portable_size_in_bytes(newb);
+            roaring_pq_element_t newelement = {
+                .size = bsize, .is_temporary = true, .bitmap = newb};
+            pq_add(pq, &newelement);
+        } else if (x2.is_temporary) {
+            roaring_bitmap_lazy_or_inplace(x2.bitmap, x1.bitmap, false);
+            x2.size = roaring_bitmap_portable_size_in_bytes(x2.bitmap);
+            pq_add(pq, &x2);
+        } else if (x1.is_temporary) {
+            roaring_bitmap_lazy_or_inplace(x1.bitmap, x2.bitmap, false);
+            x1.size = roaring_bitmap_portable_size_in_bytes(x1.bitmap);
+
+            pq_add(pq, &x1);
+        } else {
+            roaring_bitmap_t *newb =
+                roaring_bitmap_lazy_or(x1.bitmap, x2.bitmap, false);
+            uint64_t bsize = roaring_bitmap_portable_size_in_bytes(newb);
+            roaring_pq_element_t newelement = {
+                .size = bsize, .is_temporary = true, .bitmap = newb};
+
+            pq_add(pq, &newelement);
+        }
+    }
+    roaring_pq_element_t X = pq_poll(pq);
+    roaring_bitmap_t *answer = X.bitmap;
+    roaring_bitmap_repair_after_lazy(answer);
+    pq_free(pq);
+    return answer;
+}
+/* end file /home/dlemire/CVS/github/CRoaring/src/roaring_priority_queue.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/bitset_util.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/bitset_util.c"
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -1763,8 +5920,9 @@ static uint16_t vecDecodeTable_uint16[256][8] ALIGNED(32) = {
 #ifdef USEAVX
 
 size_t bitset_extract_setbits_avx2(uint64_t *array, size_t length,
-                                   uint32_t *out, size_t outcapacity,
+                                   void *vout, size_t outcapacity,
                                    uint32_t base) {
+    uint32_t *out = (uint32_t *) vout;
     uint32_t *initout = out;
     __m256i baseVec = _mm256_set1_epi32(base - 1);
     __m256i incVec = _mm256_set1_epi32(64);
@@ -1803,7 +5961,8 @@ size_t bitset_extract_setbits_avx2(uint64_t *array, size_t length,
         while ((w != 0) && (out < safeout)) {
             uint64_t t = w & -w;
             int r = __builtin_ctzll(w);
-            *out = r + base;
+            uint32_t val = r + base;
+            memcpy(out, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
             out++;
             w ^= t;
         }
@@ -1813,15 +5972,18 @@ size_t bitset_extract_setbits_avx2(uint64_t *array, size_t length,
 }
 #endif  // USEAVX
 
-size_t bitset_extract_setbits(uint64_t *bitset, size_t length, uint32_t *out,
+size_t bitset_extract_setbits(uint64_t *bitset, size_t length, void *vout,
                               uint32_t base) {
     int outpos = 0;
+    uint32_t * out = (uint32_t *) vout;
     for (size_t i = 0; i < length; ++i) {
         uint64_t w = bitset[i];
         while (w != 0) {
             uint64_t t = w & -w;
             int r = __builtin_ctzll(w);
-            out[outpos++] = r + base;
+            uint32_t val = r + base;
+            memcpy(out + outpos, &val, sizeof(uint32_t)); // should be compiled as a MOV on x64
+            outpos ++;
             w ^= t;
         }
         base += 64;
@@ -1945,6 +6107,7 @@ uint64_t bitset_set_list_withcard(void *bitset, uint64_t card,
     uint64_t shift = 6;
     const uint16_t *end = list + length;
     if (!length) return card;
+    // TODO: could unroll for performance, see bitset_set_list
     // bts is not available as an intrinsic in GCC
     __asm volatile(
         "1:\n"
@@ -1964,24 +6127,59 @@ uint64_t bitset_set_list_withcard(void *bitset, uint64_t card,
 }
 
 void bitset_set_list(void *bitset, const uint16_t *list, uint64_t length) {
-    uint64_t offset, load, pos;
-    uint64_t shift = 6;
+    uint64_t  pos;
     const uint16_t *end = list + length;
-    if (!length) return;
-    // bts is not available as an intrinsic in GCC
+
+    uint64_t shift = 6;
+    uint64_t offset;
+    uint64_t load;
+    for(;list + 3 < end; list += 4) {
+      pos =  list[0];
     __asm volatile(
-        "1:\n"
-        "movzwq (%[list]), %[pos]\n"
         "shrx %[shift], %[pos], %[offset]\n"
         "mov (%[bitset],%[offset],8), %[load]\n"
         "bts %[pos], %[load]\n"
-        "mov %[load], (%[bitset],%[offset],8)\n"
-        "add $2, %[list]\n"
-        "cmp %[list], %[end]\n"
-        "jnz 1b"
-        : [list] "+&r"(list), [load] "=&r"(load), [pos] "=&r"(pos),
-          [offset] "=&r"(offset)
-        : [end] "r"(end), [bitset] "r"(bitset), [shift] "r"(shift));
+        "mov %[load], (%[bitset],%[offset],8)"
+        : [load] "=&r"(load), [offset] "=&r"(offset)
+        : [bitset] "r"(bitset), [shift] "r"(shift), [pos] "r"(pos));
+      pos =  list[1];
+    __asm volatile(
+        "shrx %[shift], %[pos], %[offset]\n"
+        "mov (%[bitset],%[offset],8), %[load]\n"
+        "bts %[pos], %[load]\n"
+        "mov %[load], (%[bitset],%[offset],8)"
+        : [load] "=&r"(load), [offset] "=&r"(offset)
+        : [bitset] "r"(bitset), [shift] "r"(shift), [pos] "r"(pos));
+      pos =  list[2];
+    __asm volatile(
+        "shrx %[shift], %[pos], %[offset]\n"
+        "mov (%[bitset],%[offset],8), %[load]\n"
+        "bts %[pos], %[load]\n"
+        "mov %[load], (%[bitset],%[offset],8)"
+        : [load] "=&r"(load), [offset] "=&r"(offset)
+        : [bitset] "r"(bitset), [shift] "r"(shift), [pos] "r"(pos));
+      pos =  list[3];
+    __asm volatile(
+        "shrx %[shift], %[pos], %[offset]\n"
+        "mov (%[bitset],%[offset],8), %[load]\n"
+        "bts %[pos], %[load]\n"
+        "mov %[load], (%[bitset],%[offset],8)"
+        : [load] "=&r"(load), [offset] "=&r"(offset)
+        : [bitset] "r"(bitset), [shift] "r"(shift), [pos] "r"(pos));
+    }
+
+    while(list != end) {
+      pos =  list[0];
+    __asm volatile(
+        "shrx %[shift], %[pos], %[offset]\n"
+        "mov (%[bitset],%[offset],8), %[load]\n"
+        "bts %[pos], %[load]\n"
+        "mov %[load], (%[bitset],%[offset],8)"
+        : [load] "=&r"(load), [offset] "=&r"(offset)
+        : [bitset] "r"(bitset), [shift] "r"(shift), [pos] "r"(pos));
+      list ++;
+    }
+
 }
 
 uint64_t bitset_clear_list(void *bitset, uint64_t card, const uint16_t *list,
@@ -2096,3956 +6294,9 @@ void bitset_flip_list(void *bitset, const uint16_t *list, uint64_t length) {
         list++;
     }
 }
-/* end file /Users/saulius/repos/CRoaring/src/bitset_util.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/array.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/array.c"
-/*
- * array.c
- *
- */
-
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-
-extern inline bool array_container_contains(const array_container_t *arr,
-                                             uint16_t pos);
-extern int array_container_cardinality(const array_container_t *array);
-extern bool array_container_nonzero_cardinality(const array_container_t *array);
-extern void array_container_clear(array_container_t *array);
-extern int32_t array_container_serialized_size_in_bytes(int32_t card);
-extern bool array_container_empty(const array_container_t *array);
-extern bool array_container_full(const array_container_t *array);
-
-/* Create a new array with capacity size. Return NULL in case of failure. */
-array_container_t *array_container_create_given_capacity(int32_t size) {
-    array_container_t *container;
-
-    if ((container = (array_container_t *)malloc(sizeof(array_container_t))) ==
-        NULL) {
-        return NULL;
-    }
-
-    if ((container->array = (uint16_t *)malloc(sizeof(uint16_t) * size)) ==
-        NULL) {
-        free(container);
-        return NULL;
-    }
-
-    container->capacity = size;
-    container->cardinality = 0;
-
-    return container;
-}
-
-/* Create a new array. Return NULL in case of failure. */
-array_container_t *array_container_create() {
-    return array_container_create_given_capacity(ARRAY_DEFAULT_INIT_SIZE);
-}
-
-/* Duplicate container */
-array_container_t *array_container_clone(const array_container_t *src) {
-    array_container_t *newcontainer =
-        array_container_create_given_capacity(src->capacity);
-    if (newcontainer == NULL) return NULL;
-
-    newcontainer->cardinality = src->cardinality;
-
-    memcpy(newcontainer->array, src->array,
-           src->cardinality * sizeof(uint16_t));
-
-    return newcontainer;
-}
-
-/* Free memory. */
-void array_container_free(array_container_t *arr) {
-    free(arr->array);
-    arr->array = NULL;
-    free(arr);
-}
-
-static inline int32_t grow_capacity(int32_t capacity) {
-    return (capacity <= 0) ? ARRAY_DEFAULT_INIT_SIZE
-                           : capacity < 64 ? capacity * 2
-                                           : capacity < 1024 ? capacity * 3 / 2
-                                                             : capacity * 5 / 4;
-}
-
-static inline int32_t clamp(int32_t val, int32_t min, int32_t max) {
-    return ((val < min) ? min : (val > max) ? max : val);
-}
-
-/**
- * increase capacity to at least min, and to no more than max. Whether the
- * existing data needs to be copied over depends on the "preserve" parameter. If
- * preserve is false,
- * then the new content will be uninitialized, otherwise the old content is
- * copie.
- */
-void array_container_grow(array_container_t *container, int32_t min,
-                          int32_t max, bool preserve) {
-    int32_t new_capacity = clamp(grow_capacity(container->capacity), min, max);
-
-    // currently uses set max to INT32_MAX.  The next statement is not so useful
-    // then.
-    // if we are within 1/16th of the max, go to max
-    if (new_capacity > max - max / 16) new_capacity = max;
-
-    container->capacity = new_capacity;
-    uint16_t *array = container->array;
-
-    if (preserve) {
-        container->array =
-            (uint16_t *)realloc(array, new_capacity * sizeof(uint16_t));
-        if (container->array == NULL) free(array);
-    } else {
-        free(array);
-        container->array = (uint16_t *)malloc(new_capacity * sizeof(uint16_t));
-    }
-
-    // TODO: handle the case where realloc fails
-    assert(container->array != NULL);
-}
-
-/* Copy one container into another. We assume that they are distinct. */
-void array_container_copy(const array_container_t *src,
-                          array_container_t *dst) {
-    const int32_t cardinality = src->cardinality;
-    if (cardinality > dst->capacity) {
-        array_container_grow(dst, cardinality, INT32_MAX, false);
-    }
-
-    dst->cardinality = cardinality;
-    memcpy(dst->array, src->array, cardinality * sizeof(uint16_t));
-}
-
-void array_container_add_from_range(array_container_t *arr, uint32_t min,
-                                    uint32_t max, uint16_t step) {
-    for (uint32_t value = min; value < max; value += step) {
-        array_container_append(arr, value);
-    }
-}
-
-/* Computes the union of array1 and array2 and write the result to arrayout.
- * It is assumed that arrayout is distinct from both array1 and array2.
- */
-void array_container_union(const array_container_t *array_1,
-                           const array_container_t *array_2,
-                           array_container_t *out) {
-    const int32_t card_1 = array_1->cardinality, card_2 = array_2->cardinality;
-    const int32_t max_cardinality = card_1 + card_2;
-
-    if (out->capacity < max_cardinality)
-        array_container_grow(out, max_cardinality, INT32_MAX, false);
-#ifdef ROARING_VECTOR_UNION_ENABLED
-    // compute union with smallest array first
-    if (card_1 < card_2) {
-        out->cardinality = union_vector16(array_1->array, card_1,
-                                          array_2->array, card_2, out->array);
-    } else {
-        out->cardinality = union_vector16(array_2->array, card_2,
-                                          array_1->array, card_1, out->array);
-    }
-#else
-    // compute union with smallest array first
-    if (card_1 < card_2) {
-        out->cardinality = union_uint16(array_1->array, card_1, array_2->array,
-                                        card_2, out->array);
-    } else {
-        out->cardinality = union_uint16(array_2->array, card_2, array_1->array,
-                                        card_1, out->array);
-    }
-#endif
-}
-
-/* helper. a_out must be a valid array container with adequate capacity.
- * and may be same as a1.
- * Returns the cardinality of the output container. Based on Java
- * implementation Util.unsignedDifference
- */
-
-static int array_array_array_subtract(const array_container_t *a1,
-                                      const array_container_t *a2,
-                                      array_container_t *a_out) {
-    int out_card = 0;
-    int k1 = 0, k2 = 0;
-    int length1 = a1->cardinality, length2 = a2->cardinality;
-
-    if (length1 == 0) return 0;
-
-    if (length2 == 0) {
-        if (a1 != a_out)
-            memcpy(a_out->array, a1->array, sizeof(uint16_t) * length1);
-        return length1;
-    }
-
-    uint16_t s1 = a1->array[k1];
-    uint16_t s2 = a2->array[k2];
-
-    while (true) {
-        if (s1 < s2) {
-            a_out->array[out_card++] = s1;
-            ++k1;
-            if (k1 >= length1) {
-                break;
-            }
-            s1 = a1->array[k1];
-        } else if (s1 == s2) {
-            ++k1;
-            ++k2;
-            if (k1 >= length1) {
-                break;
-            }
-            if (k2 >= length2) {
-                memmove(a_out->array + out_card, a1->array + k1,
-                        sizeof(uint16_t) * (length1 - k1));
-                return out_card + length1 - k1;
-            }
-            s1 = a1->array[k1];
-            s2 = a2->array[k2];
-        } else {  // if (val1>val2)
-            ++k2;
-            if (k2 >= length2) {
-                memmove(a_out->array + out_card, a1->array + k1,
-                        sizeof(uint16_t) * (length1 - k1));
-                return out_card + length1 - k1;
-            }
-            s2 = a2->array[k2];
-        }
-    }
-    return out_card;
-}
-
-/* Computes the  difference of array1 and array2 and write the result
- * to array out.
- * Array out does not need to be distinct from array_1
- */
-void array_container_andnot(const array_container_t *array_1,
-                            const array_container_t *array_2,
-                            array_container_t *out) {
-    if (out->capacity < array_1->cardinality)
-        array_container_grow(out, array_1->cardinality, INT32_MAX, false);
-    out->cardinality = array_array_array_subtract(array_1, array_2, out);
-}
-
-/* Computes the symmetric difference of array1 and array2 and write the
- * result
- * to arrayout.
- * It is assumed that arrayout is distinct from both array1 and array2.
- */
-void array_container_xor(const array_container_t *array_1,
-                         const array_container_t *array_2,
-                         array_container_t *out) {
-    const int32_t card_1 = array_1->cardinality, card_2 = array_2->cardinality;
-    const int32_t max_cardinality = card_1 + card_2;
-
-    if (out->capacity < max_cardinality)
-        array_container_grow(out, max_cardinality, INT32_MAX, false);
-
-    // TODO something clever like the AVX union in array_util.c
-    // except where *both* occurrences of a duplicate in a sorted sequence
-    // are removed.
-
-    // just a merge for now (see TODO)
-    int pos1 = 0, pos2 = 0, pos_out = 0;
-    while (pos1 < card_1 && pos2 < card_2) {
-        const uint16_t v1 = array_1->array[pos1];
-        const uint16_t v2 = array_2->array[pos2];
-        if (v1 == v2) {
-            ++pos1;
-            ++pos2;
-            continue;
-        }
-        if (v1 < v2) {
-            out->array[pos_out++] = v1;
-            ++pos1;
-        } else {
-            out->array[pos_out++] = v2;
-            ++pos2;
-        }
-    }
-    // todo: memcpys instead
-    while (pos1 < card_1) out->array[pos_out++] = array_1->array[pos1++];
-    while (pos2 < card_2) out->array[pos_out++] = array_2->array[pos2++];
-
-    out->cardinality = pos_out;
-}
-
-static inline int32_t minimum_int32(int32_t a, int32_t b) {
-    return (a < b) ? a : b;
-}
-
-/* computes the intersection of array1 and array2 and write the result to
- * arrayout.
- * It is assumed that arrayout is distinct from both array1 and array2.
- * */
-void array_container_intersection(const array_container_t *array1,
-                                  const array_container_t *array2,
-                                  array_container_t *out) {
-    int32_t card_1 = array1->cardinality, card_2 = array2->cardinality,
-            min_card = minimum_int32(card_1, card_2);
-    const int threshold = 64;  // subject to tuning
-#ifdef USEAVX
-    min_card += sizeof(__m128i) / sizeof(uint16_t);
-#endif
-    if (out->capacity < min_card)
-        array_container_grow(out, min_card, INT32_MAX, false);
-    if (card_1 * threshold < card_2) {
-        out->cardinality = intersect_skewed_uint16(
-            array1->array, card_1, array2->array, card_2, out->array);
-    } else if (card_2 * threshold < card_1) {
-        out->cardinality = intersect_skewed_uint16(
-            array2->array, card_2, array1->array, card_1, out->array);
-    } else {
-#ifdef USEAVX
-        out->cardinality = intersect_vector16(
-            array1->array, card_1, array2->array, card_2, out->array);
-#else
-        out->cardinality = intersect_uint16(array1->array, card_1,
-                                            array2->array, card_2, out->array);
-#endif
-    }
-}
-
-/* computes the intersection of array1 and array2 and write the result to
- * array1.
- * */
-void array_container_intersection_inplace(array_container_t *src_1,
-                                          const array_container_t *src_2) {
-    // todo: can any of this be vectorized?
-    int32_t card_1 = src_1->cardinality, card_2 = src_2->cardinality;
-    const int threshold = 64;  // subject to tuning
-    if (card_1 * threshold < card_2) {
-        src_1->cardinality = intersect_skewed_uint16(
-            src_1->array, card_1, src_2->array, card_2, src_1->array);
-    } else if (card_2 * threshold < card_1) {
-        src_1->cardinality = intersect_skewed_uint16(
-            src_2->array, card_2, src_1->array, card_1, src_1->array);
-    } else {
-        src_1->cardinality = intersect_uint16(
-            src_1->array, card_1, src_2->array, card_2, src_1->array);
-    }
-}
-
-int array_container_to_uint32_array(uint32_t *out,
-                                    const array_container_t *cont,
-                                    uint32_t base) {
-    int outpos = 0;
-    for (int i = 0; i < cont->cardinality; ++i) {
-        out[outpos++] = base + cont->array[i];
-    }
-    return outpos;
-}
-
-void array_container_printf(const array_container_t *v) {
-    if (v->cardinality == 0) {
-        printf("{}");
-        return;
-    }
-    printf("{");
-    printf("%d", v->array[0]);
-    for (int i = 1; i < v->cardinality; ++i) {
-        printf(",%d", v->array[i]);
-    }
-    printf("}");
-}
-
-void array_container_printf_as_uint32_array(const array_container_t *v,
-                                            uint32_t base) {
-    if (v->cardinality == 0) {
-        return;
-    }
-    printf("%d", v->array[0] + base);
-    for (int i = 1; i < v->cardinality; ++i) {
-        printf(",%d", v->array[i] + base);
-    }
-}
-
-/* Compute the number of runs */
-int32_t array_container_number_of_runs(const array_container_t *a) {
-    // Can SIMD work here?
-    int32_t nr_runs = 0;
-    int32_t prev = -2;
-    for (const uint16_t *p = a->array; p != a->array + a->cardinality; ++p) {
-        if (*p != prev + 1) nr_runs++;
-        prev = *p;
-    }
-    return nr_runs;
-}
-
-int32_t array_container_serialize(array_container_t *container, char *buf) {
-    int32_t l, off;
-    uint16_t cardinality = (uint16_t)container->cardinality;
-
-    memcpy(buf, &cardinality, off = sizeof(cardinality));
-    l = sizeof(uint16_t) * container->cardinality;
-    if (l) memcpy(&buf[off], container->array, l);
-
-    return (off + l);
-}
-
-/**
- * Writes the underlying array to buf, outputs how many bytes were written.
- * The number of bytes written should be
- * array_container_size_in_bytes(container).
- *
- */
-int32_t array_container_write(const array_container_t *container, char *buf) {
-    if (IS_BIG_ENDIAN) {
-        // forcing little endian (could be faster)
-        for (int32_t i = 0; i < container->cardinality; i++) {
-            uint16_t val = container->array[i];
-            buf[2 * i] = (uint8_t)val;
-            buf[2 * i + 1] = (uint8_t)(val >> 8);
-        }
-    } else {
-        memcpy(buf, container->array,
-               container->cardinality * sizeof(uint16_t));
-    }
-    return array_container_size_in_bytes(container);
-}
-
-bool array_container_equals(array_container_t *container1,
-                            array_container_t *container2) {
-    if (container1->cardinality != container2->cardinality) {
-        return false;
-    }
-    // could be vectorized:
-    for (int32_t i = 0; i < container1->cardinality; ++i) {
-        if (container1->array[i] != container2->array[i]) return false;
-    }
-    return true;
-}
-
-int32_t array_container_read(int32_t cardinality, array_container_t *container,
-                             const char *buf) {
-    if (container->capacity < cardinality) {
-        array_container_grow(container, cardinality, DEFAULT_MAX_SIZE, false);
-    }
-    container->cardinality = cardinality;
-    assert(!IS_BIG_ENDIAN);  // TODO: Implement
-
-    memcpy(container->array, buf, container->cardinality * sizeof(uint16_t));
-
-    return array_container_size_in_bytes(container);
-}
-
-uint32_t array_container_serialization_len(array_container_t *container) {
-    return (sizeof(uint16_t) /* container->cardinality converted to 16 bit */ +
-            (sizeof(uint16_t) * container->cardinality));
-}
-
-void *array_container_deserialize(const char *buf, size_t buf_len) {
-    array_container_t *ptr;
-
-    if (buf_len < 2) /* capacity converted to 16 bit */
-        return (NULL);
-    else
-        buf_len -= 2;
-
-    if ((ptr = (array_container_t *)malloc(sizeof(array_container_t))) !=
-        NULL) {
-        size_t len;
-        int32_t off;
-        uint16_t cardinality;
-
-        memcpy(&cardinality, buf, off = sizeof(cardinality));
-
-        ptr->capacity = ptr->cardinality = (uint32_t)cardinality;
-        len = sizeof(uint16_t) * ptr->cardinality;
-
-        if (len != buf_len) {
-            free(ptr);
-            return (NULL);
-        }
-
-        if ((ptr->array = (uint16_t *)malloc(sizeof(uint16_t) *
-                                             ptr->capacity)) == NULL) {
-            free(ptr);
-            return (NULL);
-        }
-
-        if (len) memcpy(ptr->array, &buf[off], len);
-
-        /* Check if returned values are monotonically increasing */
-        for (int32_t i = 0, j = 0; i < ptr->cardinality; i++) {
-            if (ptr->array[i] < j) {
-                free(ptr->array);
-                free(ptr);
-                return (NULL);
-            } else
-                j = ptr->array[i];
-        }
-    }
-
-    return (ptr);
-}
-
-bool array_container_iterate(const array_container_t *cont, uint32_t base,
-                             roaring_iterator iterator, void *ptr) {
-    for (int i = 0; i < cont->cardinality; i++)
-        if (!iterator(cont->array[i] + base, ptr)) return false;
-    return true;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/array.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/bitset.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/bitset.c"
-/*
- * bitset.c
- *
- */
-#ifndef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200809L
-#endif
-#include <assert.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
-
-
-extern int bitset_container_cardinality(const bitset_container_t *bitset);
-extern bool bitset_container_nonzero_cardinality(bitset_container_t *bitset);
-extern void bitset_container_set(bitset_container_t *bitset, uint16_t pos);
-extern void bitset_container_unset(bitset_container_t *bitset, uint16_t pos);
-extern inline bool bitset_container_get(const bitset_container_t *bitset,
-                                 uint16_t pos);
-extern int32_t bitset_container_serialized_size_in_bytes();
-extern bool bitset_container_add(bitset_container_t *bitset, uint16_t pos);
-extern bool bitset_container_remove(bitset_container_t *bitset, uint16_t pos);
-extern bool bitset_container_contains(const bitset_container_t *bitset,
-                                      uint16_t pos);
-
-void bitset_container_clear(bitset_container_t *bitset) {
-    memset(bitset->array, 0, sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-    bitset->cardinality = 0;
-}
-
-void bitset_container_set_all(bitset_container_t *bitset) {
-    memset(bitset->array, INT64_C(-1),
-           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-    bitset->cardinality = (1 << 16);
-}
-
-/* Create a new bitset. Return NULL in case of failure. */
-bitset_container_t *bitset_container_create(void) {
-    bitset_container_t *bitset =
-        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
-
-    if (!bitset) {
-        return NULL;
-    }
-    // sizeof(__m256i) == 32
-    if (posix_memalign((void **)&bitset->array, 32,
-                       sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS)) {
-        free(bitset);
-        return NULL;
-    }
-    bitset_container_clear(bitset);
-    return bitset;
-}
-
-/* Copy one container into another. We assume that they are distinct. */
-void bitset_container_copy(const bitset_container_t *source,
-                           bitset_container_t *dest) {
-    dest->cardinality = source->cardinality;
-    memcpy(dest->array, source->array,
-           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-}
-
-void bitset_container_add_from_range(bitset_container_t *bitset, uint32_t min,
-                                     uint32_t max, uint16_t step) {
-    if (step == 0) return;   // refuse to crash
-    if ((64 % step) == 0) {  // step divides 64
-        uint64_t mask = 0;   // construct the repeated mask
-        for (uint32_t value = (min % step); value < 64; value += step) {
-            mask |= ((uint64_t)1 << value);
-        }
-        uint32_t firstword = min / 64;
-        uint32_t endword = (max - 1) / 64;
-        bitset->cardinality = (max - min + step - 1) / step;
-        if (firstword == endword) {
-            bitset->array[firstword] |=
-                mask & (((~UINT64_C(0)) << (min % 64)) &
-                        ((~UINT64_C(0)) >> ((-max) % 64)));
-            return;
-        }
-        bitset->array[firstword] = mask & ((~UINT64_C(0)) << (min % 64));
-        for (uint32_t i = firstword + 1; i < endword; i++)
-            bitset->array[i] = mask;
-        bitset->array[endword] = mask & ((~UINT64_C(0)) >> ((-max) % 64));
-    } else {
-        for (uint32_t value = min; value < max; value += step) {
-            bitset_container_add(bitset, value);
-        }
-    }
-}
-
-/* Free memory. */
-void bitset_container_free(bitset_container_t *bitset) {
-    free(bitset->array);
-    bitset->array = NULL;
-    free(bitset);
-}
-
-/* duplicate container. */
-bitset_container_t *bitset_container_clone(const bitset_container_t *src) {
-    bitset_container_t *bitset =
-        (bitset_container_t *)calloc(1, sizeof(bitset_container_t));
-
-    if (!bitset) {
-        return NULL;
-    }
-    // sizeof(__m256i) == 32
-    if (posix_memalign((void **)&bitset->array, 32,
-                       sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS)) {
-        free(bitset);
-        return NULL;
-    }
-    bitset->cardinality = src->cardinality;
-    memcpy(bitset->array, src->array,
-           sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-    return bitset;
-}
-
-void bitset_container_set_range(bitset_container_t *bitset, uint32_t begin,
-                                uint32_t end) {
-    bitset_set_range(bitset->array, begin, end);
-    bitset->cardinality =
-        bitset_container_compute_cardinality(bitset);  // could be smarter
-}
-
-//#define USEPOPCNT // when this is disabled
-// bitset_container_compute_cardinality uses AVX to compute hamming weight
-
-#ifdef USEAVX
-#ifndef WORDS_IN_AVX2_REG
-#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
-#endif
-/* Get the number of bits set (force computation) */
-int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
-    return avx2_harley_seal_popcount256(
-        (const __m256i *)bitset->array,
-        BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));
-}
-#else
-
-/* Get the number of bits set (force computation) */
-int bitset_container_compute_cardinality(const bitset_container_t *bitset) {
-    const uint64_t *array = bitset->array;
-    int32_t sum = 0;
-    for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 4) {
-        sum += hamming(array[i]);
-        sum += hamming(array[i + 1]);
-        sum += hamming(array[i + 2]);
-        sum += hamming(array[i + 3]);
-    }
-    return sum;
-}
-
-#endif
-
-#ifdef USEAVX
-
-#define BITSET_CONTAINER_FN_REPEAT 8
-#ifndef WORDS_IN_AVX2_REG
-#define WORDS_IN_AVX2_REG sizeof(__m256i) / sizeof(uint64_t)
-#endif
-#define LOOP_SIZE                    \
-    BITSET_CONTAINER_SIZE_IN_WORDS / \
-        ((WORDS_IN_AVX2_REG)*BITSET_CONTAINER_FN_REPEAT)
-
-/* Computes a binary operation (eg union) on bitset1 and bitset2 and write the
-   result to bitsetout */
-// clang-format off
-#define BITSET_CONTAINER_FN(opname, opsymbol, avx_intrinsic)            \
-int bitset_container_##opname##_nocard(const bitset_container_t *src_1, \
-                                       const bitset_container_t *src_2, \
-                                       bitset_container_t *dst) {       \
-    const uint8_t *array_1 = (const uint8_t *)src_1->array;             \
-    const uint8_t *array_2 = (const uint8_t *)src_2->array;             \
-    /* not using the blocking optimization for some reason*/            \
-    uint8_t *out = (uint8_t*)dst->array;                                \
-    const int innerloop = 8;                                            \
-    for (size_t i = 0;                                                  \
-        i < BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG);       \
-                                                         i+=innerloop) {\
-        __m256i A1, A2, AO;                                             \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1));                  \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2));                  \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)out, AO);                        \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 32));             \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 32));             \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+32), AO);                   \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 64));             \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 64));             \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+64), AO);                   \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 96));             \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 96));             \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+96), AO);                   \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 128));            \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 128));            \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+128), AO);                  \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 160));            \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 160));            \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+160), AO);                  \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 192));            \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 192));            \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+192), AO);                  \
-        A1 = _mm256_lddqu_si256((__m256i *)(array_1 + 224));            \
-        A2 = _mm256_lddqu_si256((__m256i *)(array_2 + 224));            \
-        AO = avx_intrinsic(A2, A1);                                     \
-        _mm256_storeu_si256((__m256i *)(out+224), AO);                  \
-        out+=256;                                                       \
-        array_1 += 256;                                                 \
-        array_2 += 256;                                                 \
-    }                                                                   \
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                      \
-    return dst->cardinality;                                            \
-}                                                                       \
-/* next, a version that updates cardinality*/                           \
-int bitset_container_##opname(const bitset_container_t *src_1,          \
-                              const bitset_container_t *src_2,          \
-                              bitset_container_t *dst) {                \
-    const __m256i *array_1 = (const __m256i *) src_1->array;            \
-    const __m256i *array_2 = (const __m256i *) src_2->array;            \
-    __m256i *out = (__m256i *) dst->array;                              \
-    dst->cardinality = avx2_harley_seal_popcount256andstore_##opname(array_2,\
-    		array_1, out,BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
-    return dst->cardinality;                                            \
-}                                                                       \
-/* next, a version that just computes the cardinality*/                 \
-int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
-                              const bitset_container_t *src_2) {        \
-    const __m256i *data1 = (const __m256i *) src_1->array;            \
-    const __m256i *data2 = (const __m256i *) src_2->array;            \
-    return avx2_harley_seal_popcount256_##opname(data2,                \
-    		data1, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
-}
-
-
-
-
-
-/*
-int bitset_container_##opname(const bitset_container_t *src_1,          \
-                              const bitset_container_t *src_2,          \
-                              bitset_container_t *dst) {                \
-    const __m256i *array_1 = (const __m256i *) src_1->array;            \
-    const __m256i *array_2 = (const __m256i *) src_2->array;            \
-    __m256i *out = (__m256i *) dst->array;                              \
-    dst->cardinality = avx2_harley_seal_popcount256andstore_##opname(array_1,\
-    		array_2, out,BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
-    return dst->cardinality;                                            \
-}                                                                       \
-*/
-
-
-/*int bitset_container_##opname##_justcard(const bitset_container_t *src_1, \
-                              const bitset_container_t *src_2) {        \
-    const __m256i *data1 = (const __m256i *) src_1->array;            \
-    const __m256i *data2 = (const __m256i *) src_2->array;            \
-    return avx2_harley_seal_popcount256_##opname(data1,                \
-    		data2, BITSET_CONTAINER_SIZE_IN_WORDS / (WORDS_IN_AVX2_REG));\
-}*/
-
-#else /* not USEAVX  */
-
-#define BITSET_CONTAINER_FN(opname, opsymbol, avxintrinsic)               \
-int bitset_container_##opname(const bitset_container_t *src_1,            \
-                              const bitset_container_t *src_2,            \
-                              bitset_container_t *dst) {                  \
-    const uint64_t *array_1 = src_1->array;                               \
-    const uint64_t *array_2 = src_2->array;                               \
-    uint64_t *out = dst->array;                                           \
-    int32_t sum = 0;                                                      \
-    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 2) {      \
-        const uint64_t word_1 = (array_1[i])opsymbol(array_2[i]),         \
-                       word_2 = (array_1[i + 1])opsymbol(array_2[i + 1]); \
-        out[i] = word_1;                                                  \
-        out[i + 1] = word_2;                                              \
-        sum += hamming(word_1);                                    \
-        sum += hamming(word_2);                                    \
-    }                                                                     \
-    dst->cardinality = sum;                                               \
-    return dst->cardinality;                                              \
-}                                                                         \
-int bitset_container_##opname##_nocard(const bitset_container_t *src_1,   \
-                                       const bitset_container_t *src_2,   \
-                                       bitset_container_t *dst) {         \
-    const uint64_t *array_1 = src_1->array, *array_2 = src_2->array;      \
-    uint64_t *out = dst->array;                                           \
-    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i++) {         \
-        out[i] = (array_1[i])opsymbol(array_2[i]);                        \
-    }                                                                     \
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;                                                \
-    return dst->cardinality;                                              \
-}                                                                         \
-int bitset_container_##opname##_justcard(const bitset_container_t *src_1,   \
-                              const bitset_container_t *src_2) {          \
-    const uint64_t *array_1 = src_1->array;                               \
-    const uint64_t *array_2 = src_2->array;                               \
-    int32_t sum = 0;                                                      \
-    for (size_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 2) {      \
-        const uint64_t word_1 = (array_1[i])opsymbol(array_2[i]),         \
-                       word_2 = (array_1[i + 1])opsymbol(array_2[i + 1]); \
-        sum += hamming(word_1);                                    \
-        sum += hamming(word_2);                                    \
-    }                                                                     \
-    return sum;                                                           \
-}
-
-#endif
-
-// we duplicate the function because other containers use the "or" term, makes API more consistent
-BITSET_CONTAINER_FN(or, |, _mm256_or_si256)
-BITSET_CONTAINER_FN(union, |, _mm256_or_si256)
-
-// we duplicate the function because other containers use the "intersection" term, makes API more consistent
-BITSET_CONTAINER_FN(and, &, _mm256_and_si256)
-BITSET_CONTAINER_FN(intersection, &, _mm256_and_si256)
-
-BITSET_CONTAINER_FN(xor, ^, _mm256_xor_si256)
-BITSET_CONTAINER_FN(andnot, &~, _mm256_andnot_si256)
-// clang-format On
-
-
-
-int bitset_container_to_uint32_array( uint32_t *out, const bitset_container_t *cont, uint32_t base) {
-#ifdef USEAVX2FORDECODING
-	if(cont->cardinality >= 8192)// heuristic
-		return (int) bitset_extract_setbits_avx2(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, out,cont->cardinality,base);
-	else
-		return (int) bitset_extract_setbits(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, out,base);
-#else
-	return (int) bitset_extract_setbits(cont->array, BITSET_CONTAINER_SIZE_IN_WORDS, out,base);
-#endif
-}
-
-/*
- * Print this container using printf (useful for debugging).
- */
-void bitset_container_printf(const bitset_container_t * v) {
-	printf("{");
-	uint32_t base = 0;
-	bool iamfirst = true;// TODO: rework so that this is not necessary yet still readable
-	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
-		uint64_t w = v->array[i];
-		while (w != 0) {
-			uint64_t t = w & -w;
-			int r = __builtin_ctzll(w);
-			if(iamfirst) {// predicted to be false
-				printf("%d",base + r);
-				iamfirst = false;
-			} else {
-				printf(",%d",base + r);
-			}
-			w ^= t;
-		}
-		base += 64;
-	}
-	printf("}");
-}
-
-
-/*
- * Print this container using printf as a comma-separated list of 32-bit integers starting at base.
- */
-void bitset_container_printf_as_uint32_array(const bitset_container_t * v, uint32_t base) {
-	bool iamfirst = true;// TODO: rework so that this is not necessary yet still readable
-	for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
-		uint64_t w = v->array[i];
-		while (w != 0) {
-			uint64_t t = w & -w;
-			int r = __builtin_ctzll(w);
-			if(iamfirst) {// predicted to be false
-				printf("%d", r + base);
-				iamfirst = false;
-			} else {
-				printf(",%d",r + base);
-			}
-			w ^= t;
-		}
-		base += 64;
-	}
-}
-
-
-// TODO: use the fast lower bound, also
-int bitset_container_number_of_runs(bitset_container_t *b) {
-  int num_runs = 0;
-  uint64_t next_word = b->array[0];
-
-  for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS-1; ++i) {
-    uint64_t word = next_word;
-    next_word = b->array[i+1];
-    num_runs += hamming((~word) & (word << 1)) + ( (word >> 63) & ~next_word);
-  }
-
-  uint64_t word = next_word;
-  num_runs += hamming((~word) & (word << 1));
-  if((word & 0x8000000000000000ULL) != 0)
-    num_runs++;
-  return num_runs;
-}
-
-int32_t bitset_container_serialize(bitset_container_t *container, char *buf) {
-  int32_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
-  memcpy(buf, container->array, l);
-  return(l);
-}
-
-
-
-int32_t bitset_container_write(const bitset_container_t *container,
-                                  char *buf) {
-if( IS_BIG_ENDIAN){
-	// forcing little endian (could be faster)
-	for(int32_t i = 0 ; i < BITSET_CONTAINER_SIZE_IN_WORDS; i++) {
-		uint64_t val = container->array[i];
-		val = __builtin_bswap64(val);
-		memcpy(buf + i * sizeof(uint64_t), &val, sizeof(uint64_t));
-	}
-} else {
-	memcpy(buf, container->array, BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t));
-}
-	return bitset_container_size_in_bytes(container);
-}
-
-
-int32_t bitset_container_read(int32_t cardinality, bitset_container_t *container,
-		const char *buf)  {
-	container->cardinality = cardinality;
-	assert(!IS_BIG_ENDIAN);// TODO: Implement
-
-	memcpy(container->array, buf, BITSET_CONTAINER_SIZE_IN_WORDS * sizeof(uint64_t));
-	return bitset_container_size_in_bytes(container);
-}
-
-uint32_t bitset_container_serialization_len() {
-  return(sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS);
-}
-
-void* bitset_container_deserialize(const char *buf, size_t buf_len) {
-  bitset_container_t *ptr;
-  size_t l = sizeof(uint64_t) * BITSET_CONTAINER_SIZE_IN_WORDS;
-
-  if(l != buf_len)
-    return(NULL);
-
-  if((ptr = (bitset_container_t *)malloc(sizeof(bitset_container_t))) != NULL) {
-    memcpy(ptr, buf, sizeof(bitset_container_t));
-    // sizeof(__m256i) == 32
-    if(posix_memalign((void **)&ptr->array, 32, l)) {
-      free(ptr);
-      return(NULL);
-    }
-
-    memcpy(ptr->array, buf, l);
-    ptr->cardinality = bitset_container_compute_cardinality(ptr);
-  }
-
-  return((void*)ptr);
-}
-
-bool bitset_container_iterate(const bitset_container_t *cont, uint32_t base, roaring_iterator iterator, void *ptr) {
-  for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
-    uint64_t w = cont->array[i];
-    while (w != 0) {
-      uint64_t t = w & -w;
-      int r = __builtin_ctzll(w);
-      if(!iterator(r + base, ptr)) return false;
-      w ^= t;
-    }
-    base += 64;
-  }
-  return true;
-}
-
-
-bool bitset_container_equals(bitset_container_t *container1, bitset_container_t *container2) {
-	if((container1->cardinality != BITSET_UNKNOWN_CARDINALITY) && (container2->cardinality != BITSET_UNKNOWN_CARDINALITY)) {
-		if(container1->cardinality != container2->cardinality) {
-			return false;
-		}
-	}
-	for(int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i ) {
-		if(container1->array[i] != container2->array[i]) {
-			return false;
-		}
-	}
-	return true;
-}
-
-bool bitset_container_select(const bitset_container_t *container, uint32_t *start_rank, uint32_t rank, uint32_t *element) {
-    int card = bitset_container_cardinality(container);
-    if(rank >= *start_rank + card) {
-        *start_rank += card;
-        return false;
-    }
-    const uint64_t *array = container->array;
-    int32_t size;
-    for (int i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; i += 1) {
-        size = hamming(array[i]);
-        if(rank <= *start_rank + size) {
-            uint64_t w = container->array[i];
-            uint16_t base = i*64;
-            while (w != 0) {
-                uint64_t t = w & -w;
-                int r = __builtin_ctzll(w);
-                if(*start_rank == rank) {
-                    *element = r+base;
-                    return true;
-                }
-                w ^= t;
-                *start_rank += 1;
-            }
-        }
-        else
-            *start_rank += size;
-    }
-    assert(false);
-    __builtin_unreachable();
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/bitset.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/containers.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/containers.c"
-
-
-extern  inline const void *container_unwrap_shared(
-       const void *candidate_shared_container, uint8_t *type);
-
-extern const char *get_container_name(uint8_t typecode);
-
-extern int container_get_cardinality(const void *container, uint8_t typecode);
-
-extern void *container_iand(void *c1, uint8_t type1, const void *c2,
-                            uint8_t type2, uint8_t *result_type);
-
-extern void *container_ior(void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
-
-extern void *container_ixor(void *c1, uint8_t type1, const void *c2,
-                            uint8_t type2, uint8_t *result_type);
-
-extern void *container_iandnot(void *c1, uint8_t type1, const void *c2,
-                               uint8_t type2, uint8_t *result_type);
-
-void container_free(void *container, uint8_t typecode) {
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            bitset_container_free((bitset_container_t *)container);
-            break;
-        case ARRAY_CONTAINER_TYPE_CODE:
-            array_container_free((array_container_t *)container);
-            break;
-        case RUN_CONTAINER_TYPE_CODE:
-            run_container_free((run_container_t *)container);
-            break;
-        case SHARED_CONTAINER_TYPE_CODE:
-            shared_container_free((shared_container_t *)container);
-            break;
-        default:
-            assert(false);
-            __builtin_unreachable();
-    }
-}
-
-void container_printf(const void *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            bitset_container_printf((const bitset_container_t *)container);
-            return;
-        case ARRAY_CONTAINER_TYPE_CODE:
-            array_container_printf((const array_container_t *)container);
-            return;
-        case RUN_CONTAINER_TYPE_CODE:
-            run_container_printf((const run_container_t *)container);
-            return;
-        default:
-            __builtin_unreachable();
-    }
-}
-
-void container_printf_as_uint32_array(const void *container, uint8_t typecode,
-                                      uint32_t base) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            bitset_container_printf_as_uint32_array(
-                (const bitset_container_t *)container, base);
-            return;
-        case ARRAY_CONTAINER_TYPE_CODE:
-            array_container_printf_as_uint32_array(
-                (const array_container_t *)container, base);
-            return;
-        case RUN_CONTAINER_TYPE_CODE:
-            run_container_printf_as_uint32_array(
-                (const run_container_t *)container, base);
-            return;
-            return;
-        default:
-            __builtin_unreachable();
-    }
-}
-
-int32_t container_serialize(const void *container, uint8_t typecode,
-                            char *buf) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return (bitset_container_serialize((bitset_container_t *)container,
-                                               buf));
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return (
-                array_container_serialize((array_container_t *)container, buf));
-        case RUN_CONTAINER_TYPE_CODE:
-            return (run_container_serialize((run_container_t *)container, buf));
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (-1);
-    }
-}
-
-uint32_t container_serialization_len(const void *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return bitset_container_serialization_len();
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return array_container_serialization_len(
-                (array_container_t *)container);
-        case RUN_CONTAINER_TYPE_CODE:
-            return run_container_serialization_len(
-                (run_container_t *)container);
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (0);
-    }
-}
-
-void *container_deserialize(uint8_t typecode, const char *buf, size_t buf_len) {
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return (bitset_container_deserialize(buf, buf_len));
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return (array_container_deserialize(buf, buf_len));
-        case RUN_CONTAINER_TYPE_CODE:
-            return (run_container_deserialize(buf, buf_len));
-        case SHARED_CONTAINER_TYPE_CODE:
-            printf("this should never happen.\n");
-            assert(0);
-            __builtin_unreachable();
-            return (NULL);
-        default:
-            assert(0);
-            __builtin_unreachable();
-            return (NULL);
-    }
-}
-
-extern bool container_nonzero_cardinality(const void *container,
-                                          uint8_t typecode);
-
-extern void container_free(void *container, uint8_t typecode);
-
-extern int container_to_uint32_array(uint32_t *output, const void *container,
-                                     uint8_t typecode, uint32_t base);
-
-extern void *container_add(void *container, uint16_t val, uint8_t typecode,
-                           uint8_t *new_typecode);
-
-extern inline bool container_contains(const void *container, uint16_t val,
-                               uint8_t typecode);
-
-extern void *container_clone(const void *container, uint8_t typecode);
-
-extern void *container_and(const void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
-
-extern void *container_or(const void *c1, uint8_t type1, const void *c2,
-                          uint8_t type2, uint8_t *result_type);
-
-extern void *container_xor(const void *c1, uint8_t type1, const void *c2,
-                           uint8_t type2, uint8_t *result_type);
-
-void *get_copy_of_container(void *container, uint8_t *typecode,
-                            bool copy_on_write) {
-    if (copy_on_write) {
-        shared_container_t *shared_container;
-        if (*typecode == SHARED_CONTAINER_TYPE_CODE) {
-            shared_container = (shared_container_t *)container;
-            shared_container->counter += 1;
-            return shared_container;
-        }
-        assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
-
-        if ((shared_container = (shared_container_t *)malloc(
-                 sizeof(shared_container_t))) == NULL) {
-            return NULL;
-        }
-
-        shared_container->container = container;
-        shared_container->typecode = *typecode;
-
-        shared_container->counter = 2;
-        *typecode = SHARED_CONTAINER_TYPE_CODE;
-
-        return shared_container;
-    }  // copy_on_write
-    // otherwise, no copy on write...
-    const void *actualcontainer =
-        container_unwrap_shared((const void *)container, typecode);
-    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
-    return container_clone(actualcontainer, *typecode);
-}
-/**
- * Copies a container, requires a typecode. This allocates new memory, caller
- * is responsible for deallocation.
- */
-void *container_clone(const void *container, uint8_t typecode) {
-    container = container_unwrap_shared(container, &typecode);
-    switch (typecode) {
-        case BITSET_CONTAINER_TYPE_CODE:
-            return bitset_container_clone((bitset_container_t *)container);
-        case ARRAY_CONTAINER_TYPE_CODE:
-            return array_container_clone((array_container_t *)container);
-        case RUN_CONTAINER_TYPE_CODE:
-            return run_container_clone((run_container_t *)container);
-        case SHARED_CONTAINER_TYPE_CODE:
-            printf("shared containers are not cloneable\n");
-            assert(false);
-            return NULL;
-        default:
-            assert(false);
-            __builtin_unreachable();
-            return NULL;
-    }
-}
-
-void *shared_container_extract_copy(shared_container_t *container,
-                                    uint8_t *typecode) {
-    assert(container->counter > 0);
-    assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
-    container->counter--;
-    *typecode = container->typecode;
-    void *answer;
-    if (container->counter == 0) {
-        answer = container->container;
-        container->container = NULL;  // paranoid
-        free(container);
-    } else {
-        answer = container_clone(container->container, *typecode);
-    }
-    assert(*typecode != SHARED_CONTAINER_TYPE_CODE);
-    return answer;
-}
-
-void shared_container_free(shared_container_t *container) {
-    assert(container->counter > 0);
-    container->counter--;
-    if (container->counter == 0) {
-        assert(container->typecode != SHARED_CONTAINER_TYPE_CODE);
-        container_free(container->container, container->typecode);
-        container->container = NULL;  // paranoid
-        free(container);
-    }
-}
-
-extern void *container_not(const void *c1, uint8_t type1, uint8_t *result_type);
-
-extern void *container_not_range(const void *c1, uint8_t type1,
-                                 uint32_t range_start, uint32_t range_end,
-                                 uint8_t *result_type);
-
-extern void *container_inot(void *c1, uint8_t type1, uint8_t *result_type);
-
-extern void *container_inot_range(void *c1, uint8_t type1, uint32_t range_start,
-                                  uint32_t range_end, uint8_t *result_type);
-
-extern void *container_range_of_ones(uint32_t range_start, uint32_t range_end,
-                                     uint8_t *result_type);
-
-// where are the correponding things for union and intersection??
-extern void *container_lazy_xor(const void *c1, uint8_t type1, const void *c2,
-                                uint8_t type2, uint8_t *result_type);
-
-extern void *container_lazy_ixor(void *c1, uint8_t type1, const void *c2,
-                                 uint8_t type2, uint8_t *result_type);
-
-extern void *container_andnot(const void *c1, uint8_t type1, const void *c2,
-                              uint8_t type2, uint8_t *result_type);
-/* end file /Users/saulius/repos/CRoaring/src/containers/containers.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/convert.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/convert.c"
-#include <stdio.h>
-
-
-// file contains grubby stuff that must know impl. details of all container
-// types.
-bitset_container_t *bitset_container_from_array(const array_container_t *a) {
-    bitset_container_t *ans = bitset_container_create();
-    int limit = array_container_cardinality(a);
-    for (int i = 0; i < limit; ++i) bitset_container_set(ans, a->array[i]);
-    return ans;
-}
-
-bitset_container_t *bitset_container_from_run(const run_container_t *arr) {
-    int card = run_container_cardinality(arr);
-    bitset_container_t *answer = bitset_container_create();
-    for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
-        rle16_t vl = arr->runs[rlepos];
-        bitset_set_lenrange(answer->array, vl.value, vl.length);
-    }
-    answer->cardinality = card;
-    return answer;
-}
-
-array_container_t *array_container_from_run(const run_container_t *arr) {
-    array_container_t *answer =
-        array_container_create_given_capacity(run_container_cardinality(arr));
-    answer->cardinality = 0;
-    for (int rlepos = 0; rlepos < arr->n_runs; ++rlepos) {
-        int run_start = arr->runs[rlepos].value;
-        int run_end = run_start + arr->runs[rlepos].length;
-
-        for (int run_value = run_start; run_value <= run_end; ++run_value) {
-            answer->array[answer->cardinality++] = (uint16_t)run_value;
-        }
-    }
-    return answer;
-}
-
-array_container_t *array_container_from_bitset(const bitset_container_t *bits) {
-    array_container_t *result =
-        array_container_create_given_capacity(bits->cardinality);
-    result->cardinality = bits->cardinality;
-    //  sse version ends up being slower here
-    // (bitset_extract_setbits_sse_uint16)
-    // because of the sparsity of the data
-    bitset_extract_setbits_uint16(bits->array, BITSET_CONTAINER_SIZE_IN_WORDS,
-                                  result->array, 0);
-    return result;
-}
-
-/* assumes that container has adequate space.  Run from [s,e] (inclusive) */
-static void add_run(run_container_t *r, int s, int e) {
-    r->runs[r->n_runs].value = s;
-    r->runs[r->n_runs].length = e - s;
-    r->n_runs++;
-}
-
-run_container_t *run_container_from_array(const array_container_t *c) {
-    int32_t n_runs = array_container_number_of_runs(c);
-    run_container_t *answer = run_container_create_given_capacity(n_runs);
-    int prev = -2;
-    int run_start = -1;
-    int32_t card = c->cardinality;
-    if (card == 0) return answer;
-    for (int i = 0; i < card; ++i) {
-        const uint16_t cur_val = c->array[i];
-        if (cur_val != prev + 1) {
-            // new run starts; flush old one, if any
-            if (run_start != -1) add_run(answer, run_start, prev);
-            run_start = cur_val;
-        }
-        prev = c->array[i];
-    }
-    // now prev is the last seen value
-    add_run(answer, run_start, prev);
-    // assert(run_container_cardinality(answer) == c->cardinality);
-    return answer;
-}
-
-/**
- * Convert the runcontainer to either a Bitmap or an Array Container, depending
- * on the cardinality.  Frees the container.
- * Allocates and returns new container, which caller is responsible for freeing
- */
-
-void *convert_to_bitset_or_array_container(run_container_t *r, int32_t card,
-                                           uint8_t *resulttype) {
-    if (card <= DEFAULT_MAX_SIZE) {
-        array_container_t *answer = array_container_create_given_capacity(card);
-        answer->cardinality = 0;
-        for (int rlepos = 0; rlepos < r->n_runs; ++rlepos) {
-            uint16_t run_start = r->runs[rlepos].value;
-            uint16_t run_end = run_start + r->runs[rlepos].length;
-            for (uint16_t run_value = run_start; run_value <= run_end;
-                 ++run_value) {
-                answer->array[answer->cardinality++] = run_value;
-            }
-        }
-        assert(card == answer->cardinality);
-        *resulttype = ARRAY_CONTAINER_TYPE_CODE;
-        run_container_free(r);
-        return answer;
-    }
-    bitset_container_t *answer = bitset_container_create();
-    for (int rlepos = 0; rlepos < r->n_runs; ++rlepos) {
-        uint16_t run_start = r->runs[rlepos].value;
-        bitset_set_lenrange(answer->array, run_start, r->runs[rlepos].length);
-    }
-    answer->cardinality = card;
-    *resulttype = BITSET_CONTAINER_TYPE_CODE;
-    run_container_free(r);
-    return answer;
-}
-
-/* Converts a run container to either an array or a bitset, IF it saves space.
- */
-/* If a conversion occurs, the caller is responsible to free the original
- * container and
- * he becomes responsible to free the new one. */
-void *convert_run_to_efficient_container(run_container_t *c,
-                                         uint8_t *typecode_after) {
-    int32_t size_as_run_container =
-        run_container_serialized_size_in_bytes(c->n_runs);
-
-    int32_t size_as_bitset_container =
-        bitset_container_serialized_size_in_bytes();
-    int32_t card = run_container_cardinality(c);
-    int32_t size_as_array_container =
-        array_container_serialized_size_in_bytes(card);
-
-    int32_t min_size_non_run =
-        size_as_bitset_container < size_as_array_container
-            ? size_as_bitset_container
-            : size_as_array_container;
-    if (size_as_run_container <= min_size_non_run) {  // no conversion
-        *typecode_after = RUN_CONTAINER_TYPE_CODE;
-        return c;
-    }
-    if (card <= DEFAULT_MAX_SIZE) {
-        // to array
-        array_container_t *answer = array_container_create_given_capacity(card);
-        answer->cardinality = 0;
-        for (int rlepos = 0; rlepos < c->n_runs; ++rlepos) {
-            int run_start = c->runs[rlepos].value;
-            int run_end = run_start + c->runs[rlepos].length;
-
-            for (int run_value = run_start; run_value <= run_end; ++run_value) {
-                answer->array[answer->cardinality++] = (uint16_t)run_value;
-            }
-        }
-        *typecode_after = ARRAY_CONTAINER_TYPE_CODE;
-        return answer;
-    }
-
-    // else to bitset
-    bitset_container_t *answer = bitset_container_create();
-
-    for (int rlepos = 0; rlepos < c->n_runs; ++rlepos) {
-        int start = c->runs[rlepos].value;
-        int end = start + c->runs[rlepos].length;
-        bitset_set_range(answer->array, start, end + 1);
-    }
-    answer->cardinality = card;
-    *typecode_after = BITSET_CONTAINER_TYPE_CODE;
-    return answer;
-}
-
-// like convert_run_to_efficient_container but frees the old result if needed
-void *convert_run_to_efficient_container_and_free(run_container_t *c,
-                                                  uint8_t *typecode_after) {
-    void *answer = convert_run_to_efficient_container(c, typecode_after);
-    if (answer != c) run_container_free(c);
-    return answer;
-}
-
-/* once converted, the original container is disposed here, rather than
-   in roaring_array
-*/
-
-// TODO: split into run-  array-  and bitset-  subfunctions for sanity;
-// a few function calls won't really matter.
-
-void *convert_run_optimize(void *c, uint8_t typecode_original,
-                           uint8_t *typecode_after) {
-    if (typecode_original == RUN_CONTAINER_TYPE_CODE) {
-        void *newc = convert_run_to_efficient_container((run_container_t *)c,
-                                                        typecode_after);
-        if (newc != c) {
-            container_free(c, typecode_original);
-        }
-        return newc;
-    } else if (typecode_original == ARRAY_CONTAINER_TYPE_CODE) {
-        // it might need to be converted to a run container.
-        array_container_t *c_qua_array = (array_container_t *)c;
-        int32_t n_runs = array_container_number_of_runs(c_qua_array);
-        int32_t size_as_run_container =
-            run_container_serialized_size_in_bytes(n_runs);
-        int32_t card = array_container_cardinality(c_qua_array);
-        int32_t size_as_array_container =
-            array_container_serialized_size_in_bytes(card);
-
-        if (size_as_run_container >= size_as_array_container) {
-            *typecode_after = ARRAY_CONTAINER_TYPE_CODE;
-            return c;
-        }
-        // else convert array to run container
-        run_container_t *answer = run_container_create_given_capacity(n_runs);
-        int prev = -2;
-        int run_start = -1;
-
-        assert(card > 0);
-        for (int i = 0; i < card; ++i) {
-            uint16_t cur_val = c_qua_array->array[i];
-            if (cur_val != prev + 1) {
-                // new run starts; flush old one, if any
-                if (run_start != -1) add_run(answer, run_start, prev);
-                run_start = cur_val;
-            }
-            prev = c_qua_array->array[i];
-        }
-        assert(run_start >= 0);
-        // now prev is the last seen value
-        add_run(answer, run_start, prev);
-        *typecode_after = RUN_CONTAINER_TYPE_CODE;
-        array_container_free(c_qua_array);
-        return answer;
-    } else if (typecode_original ==
-               BITSET_CONTAINER_TYPE_CODE) {  // run conversions on bitset
-        // does bitset need conversion to run?
-        bitset_container_t *c_qua_bitset = (bitset_container_t *)c;
-        int32_t n_runs = bitset_container_number_of_runs(c_qua_bitset);
-        int32_t size_as_run_container =
-            run_container_serialized_size_in_bytes(n_runs);
-        int32_t size_as_bitset_container =
-            bitset_container_serialized_size_in_bytes();
-
-        if (size_as_bitset_container <= size_as_run_container) {
-            // no conversion needed.
-            *typecode_after = BITSET_CONTAINER_TYPE_CODE;
-            return c;
-        }
-        // bitset to runcontainer (ported from Java  RunContainer(
-        // BitmapContainer bc, int nbrRuns))
-        assert(n_runs > 0);  // no empty bitmaps
-        run_container_t *answer = run_container_create_given_capacity(n_runs);
-
-        int long_ctr = 0;
-        uint64_t cur_word = c_qua_bitset->array[0];
-        int run_count = 0;
-        while (true) {
-            while (cur_word == UINT64_C(0) &&
-                   long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
-                cur_word = c_qua_bitset->array[++long_ctr];
-
-            if (cur_word == UINT64_C(0)) {
-                bitset_container_free(c_qua_bitset);
-                *typecode_after = RUN_CONTAINER_TYPE_CODE;
-                return answer;
-            }
-
-            int local_run_start = __builtin_ctzll(cur_word);
-            int run_start = local_run_start + 64 * long_ctr;
-            uint64_t cur_word_with_1s = cur_word | (cur_word - 1);
-
-            int run_end = 0;
-            while (cur_word_with_1s == UINT64_C(-1) &&
-                   long_ctr < BITSET_CONTAINER_SIZE_IN_WORDS - 1)
-                cur_word_with_1s = c_qua_bitset->array[++long_ctr];
-
-            if (cur_word_with_1s == UINT64_C(-1)) {
-                run_end = 64 + long_ctr * 64;  // exclusive, I guess
-                add_run(answer, run_start, run_end - 1);
-                bitset_container_free(c_qua_bitset);
-                *typecode_after = RUN_CONTAINER_TYPE_CODE;
-                return answer;
-            }
-            int local_run_end = __builtin_ctzll(~cur_word_with_1s);
-            run_end = local_run_end + long_ctr * 64;
-            add_run(answer, run_start, run_end - 1);
-            run_count++;
-            cur_word = cur_word_with_1s & (cur_word_with_1s + 1);
-        }
-        return answer;
-    } else {
-        assert(false);
-        __builtin_unreachable();
-        return NULL;
-    }
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/convert.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_andnot.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_andnot.c"
-/*
- * mixed_andnot.c.  More methods since operation is not symmetric,
- * except no "wide" andnot , so no lazy options motivated.
- */
-
-#include <assert.h>
-#include <string.h>
-
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst, a valid array container that could be the same as dst.*/
-void array_bitset_container_andnot(const array_container_t *src_1,
-                                   const bitset_container_t *src_2,
-                                   array_container_t *dst) {
-    // follows Java implementation as of June 2016
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
-    int32_t newcard = 0;
-    const int32_t origcard = src_1->cardinality;
-    for (int i = 0; i < origcard; ++i) {
-        uint16_t key = src_1->array[i];
-        if (!bitset_container_contains(src_2, key)) {
-            dst->array[newcard++] = key;
-        }
-    }
-    dst->cardinality = newcard;
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * src_1 */
-
-void array_bitset_container_iandnot(array_container_t *src_1,
-                                    const bitset_container_t *src_2) {
-    array_bitset_container_andnot(src_1, src_2, src_1);
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst, which does not initially have a valid container.
- * Return true for a bitset result; false for array
- */
-
-bool bitset_array_container_andnot(const bitset_container_t *src_1,
-                                   const array_container_t *src_2, void **dst) {
-    // Java did this directly, but we have option of asm or avx
-    bitset_container_t *result = bitset_container_create();
-    bitset_container_copy(src_1, result);
-    result->cardinality = bitset_clear_list(result->array, result->cardinality,
-                                            src_2->array, src_2->cardinality);
-
-    // do required type conversions.
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;
-    }
-    *dst = result;
-    return true;
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-bool bitset_array_container_iandnot(bitset_container_t *src_1,
-                                    const array_container_t *src_2,
-                                    void **dst) {
-    *dst = src_1;
-    src_1->cardinality = bitset_clear_list(src_1->array, src_1->cardinality,
-                                           src_2->array, src_2->cardinality);
-
-    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(src_1);
-        bitset_container_free(src_1);
-        return false;  // not bitset
-    } else
-        return true;
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool run_bitset_container_andnot(const run_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
-    // follows the Java implementation as of June 2016
-    int card = run_container_cardinality(src_1);
-    if (card <= DEFAULT_MAX_SIZE) {
-        // must be an array
-        array_container_t *answer = array_container_create_given_capacity(card);
-        answer->cardinality = 0;
-        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-            rle16_t rle = src_1->runs[rlepos];
-            for (int run_value = rle.value; run_value <= rle.value + rle.length;
-                 ++run_value) {
-                if (!bitset_container_get(src_2, (uint16_t)run_value)) {
-                    answer->array[answer->cardinality++] = (uint16_t)run_value;
-                }
-            }
-        }
-        *dst = answer;
-        return false;
-    } else {  // we guess it will be a bitset, though have to check guess when
-              // done
-        bitset_container_t *answer = bitset_container_clone(src_2);
-
-        uint32_t last_pos = 0;
-        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-            rle16_t rle = src_1->runs[rlepos];
-
-            uint32_t start = rle.value;
-            uint32_t end = start + rle.length + 1;
-            bitset_reset_range(answer->array, last_pos, start);
-            bitset_flip_range(answer->array, start, end);
-            last_pos = end;
-        }
-        bitset_reset_range(answer->array, last_pos, (uint32_t)(1 << 16));
-
-        answer->cardinality = bitset_container_compute_cardinality(answer);
-
-        if (answer->cardinality <= DEFAULT_MAX_SIZE) {
-            *dst = array_container_from_bitset(answer);
-            bitset_container_free(answer);
-            return false;  // not bitset
-        }
-        *dst = answer;
-        return true;  // bitset
-    }
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool run_bitset_container_iandnot(run_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst) {
-    // dummy implementation
-    bool ans = run_bitset_container_andnot(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset").  dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool bitset_run_container_andnot(const bitset_container_t *src_1,
-                                 const run_container_t *src_2, void **dst) {
-    // follows Java implementation
-    bitset_container_t *result = bitset_container_create();
-
-    bitset_container_copy(src_1, result);
-    for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
-        rle16_t rle = src_2->runs[rlepos];
-        bitset_reset_range(result->array, rle.value,
-                           rle.value + rle.length + UINT32_C(1));
-    }
-    result->cardinality = bitset_container_compute_cardinality(result);
-
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;  // not bitset
-    }
-    *dst = result;
-    return true;  // bitset
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-bool bitset_run_container_iandnot(bitset_container_t *src_1,
-                                  const run_container_t *src_2, void **dst) {
-    *dst = src_1;
-
-    for (int32_t rlepos = 0; rlepos < src_2->n_runs; ++rlepos) {
-        rle16_t rle = src_2->runs[rlepos];
-        bitset_reset_range(src_1->array, rle.value,
-                           rle.value + rle.length + UINT32_C(1));
-    }
-    src_1->cardinality = bitset_container_compute_cardinality(src_1);
-
-    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(src_1);
-        bitset_container_free(src_1);
-        return false;  // not bitset
-    } else
-        return true;
-}
-
-/* helper. a_out must be a valid array container with adequate capacity.
- * Returns the cardinality of the output container. Partly Based on Java
- * implementation Util.unsignedDifference.
- *
- * TODO: Util.unsignedDifference does not use advanceUntil.  Is it cheaper
- * to avoid advanceUntil?
- */
-
-static int run_array_array_subtract(const run_container_t *r,
-                                    const array_container_t *a_in,
-                                    array_container_t *a_out) {
-    int out_card = 0;
-    int32_t in_array_pos =
-        -1;  // since advanceUntil always assumes we start the search AFTER this
-
-    for (int rlepos = 0; rlepos < r->n_runs; rlepos++) {
-        int32_t start = r->runs[rlepos].value;
-        int32_t end = start + r->runs[rlepos].length + 1;
-
-        in_array_pos = advanceUntil(a_in->array, in_array_pos,
-                                    a_in->cardinality, (uint16_t)start);
-
-        if (in_array_pos >= a_in->cardinality) {  // run has no items subtracted
-            for (int32_t i = start; i < end; ++i)
-                a_out->array[out_card++] = (uint16_t)i;
-        } else {
-            uint16_t next_nonincluded = a_in->array[in_array_pos];
-            if (next_nonincluded >= end) {
-                // another case when run goes unaltered
-                for (int32_t i = start; i < end; ++i)
-                    a_out->array[out_card++] = (uint16_t)i;
-                in_array_pos--;  // ensure we see this item again if necessary
-            } else {
-                for (int32_t i = start; i < end; ++i)
-                    if (i != next_nonincluded)
-                        a_out->array[out_card++] = (uint16_t)i;
-                    else  // 0 should ensure  we don't match
-                        next_nonincluded =
-                            (in_array_pos + 1 >= a_in->cardinality)
-                                ? 0
-                                : a_in->array[++in_array_pos];
-                in_array_pos--;  // see again
-            }
-        }
-    }
-    return out_card;
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any type of container.
- */
-
-int run_array_container_andnot(const run_container_t *src_1,
-                               const array_container_t *src_2, void **dst) {
-    // follows the Java impl as of June 2016
-
-    int card = run_container_cardinality(src_1);
-    const int arbitrary_threshold = 32;
-
-    if (card <= arbitrary_threshold) {
-        if (src_2->cardinality == 0) {
-            *dst = run_container_clone(src_1);
-            return RUN_CONTAINER_TYPE_CODE;
-        }
-        // Java's "lazyandNot.toEfficientContainer" thing
-        run_container_t *answer = run_container_create_given_capacity(
-            card + array_container_cardinality(src_2));
-
-        int rlepos = 0;
-        int xrlepos = 0;  // "x" is src_2
-        rle16_t rle = src_1->runs[rlepos];
-        int32_t start = rle.value;
-        int32_t end = start + rle.length + 1;
-        int32_t xstart = src_2->array[xrlepos];
-
-        while ((rlepos < src_1->n_runs) && (xrlepos < src_2->cardinality)) {
-            if (end <= xstart) {
-                // output the first run
-                answer->runs[answer->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(end - start - 1)};
-                rlepos++;
-                if (rlepos < src_1->n_runs) {
-                    start = src_1->runs[rlepos].value;
-                    end = start + src_1->runs[rlepos].length + 1;
-                }
-            } else if (xstart + 1 <= start) {
-                // exit the second run
-                xrlepos++;
-                if (xrlepos < src_2->cardinality) {
-                    xstart = src_2->array[xrlepos];
-                }
-            } else {
-                if (start < xstart) {
-                    answer->runs[answer->n_runs++] =
-                        (rle16_t){.value = (uint16_t)start,
-                                  .length = (uint16_t)(xstart - start - 1)};
-                }
-                if (xstart + 1 < end) {
-                    start = xstart + 1;
-                } else {
-                    rlepos++;
-                    if (rlepos < src_1->n_runs) {
-                        start = src_1->runs[rlepos].value;
-                        end = start + src_1->runs[rlepos].length + 1;
-                    }
-                }
-            }
-        }
-        if (rlepos < src_1->n_runs) {
-            answer->runs[answer->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
-            rlepos++;
-            if (rlepos < src_1->n_runs) {
-                memcpy(answer->runs + answer->n_runs, src_1->runs + rlepos,
-                       (src_1->n_runs - rlepos) * sizeof(rle16_t));
-                answer->n_runs += (src_1->n_runs - rlepos);
-            }
-        }
-        uint8_t return_type;
-        *dst = convert_run_to_efficient_container(answer, &return_type);
-        if (answer != *dst) run_container_free(answer);
-        return return_type;
-    }
-    // else it's a bitmap or array
-
-    if (card <= DEFAULT_MAX_SIZE) {
-        array_container_t *ac = array_container_create_given_capacity(card);
-        // nb Java code used a generic iterator-based merge to compute
-        // difference
-        ac->cardinality = run_array_array_subtract(src_1, src_2, ac);
-        *dst = ac;
-        return ARRAY_CONTAINER_TYPE_CODE;
-    }
-    bitset_container_t *ans = bitset_container_from_run(src_1);
-    bool result_is_bitset = bitset_array_container_iandnot(ans, src_2, dst);
-    return (result_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                             : ARRAY_CONTAINER_TYPE_CODE);
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-int run_array_container_iandnot(run_container_t *src_1,
-                                const array_container_t *src_2, void **dst) {
-    // dummy implementation same as June 2016 Java
-    int ans = run_array_container_andnot(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
-}
-
-/* dst must be a valid array container, allowed to be src_1 */
-
-void array_run_container_andnot(const array_container_t *src_1,
-                                const run_container_t *src_2,
-                                array_container_t *dst) {
-    // basically following Java impl as of June 2016
-    if (src_1->cardinality > dst->capacity)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
-
-    if (src_2->n_runs == 0) {
-        memmove(dst->array, src_1->array,
-                sizeof(uint16_t) * src_1->cardinality);
-        dst->cardinality = src_1->cardinality;
-        return;
-    }
-    int32_t run_start = src_2->runs[0].value;
-    int32_t run_end = run_start + src_2->runs[0].length;
-    int which_run = 0;
-
-    uint16_t val = 0;
-    int dest_card = 0;
-    for (int i = 0; i < src_1->cardinality; ++i) {
-        val = src_1->array[i];
-        if (val < run_start)
-            dst->array[dest_card++] = val;
-        else if (val <= run_end) {
-            ;  // omitted item
-        } else {
-            do {
-                if (which_run + 1 < src_2->n_runs) {
-                    ++which_run;
-                    run_start = src_2->runs[which_run].value;
-                    run_end = run_start + src_2->runs[which_run].length;
-
-                } else
-                    run_start = run_end = (1 << 16) + 1;
-            } while (val > run_end);
-            --i;
-        }
-    }
-    dst->cardinality = dest_card;
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-void array_run_container_iandnot(array_container_t *src_1,
-                                 const run_container_t *src_2) {
-    array_run_container_andnot(src_1, src_2, src_1);
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int run_run_container_andnot(const run_container_t *src_1,
-                             const run_container_t *src_2, void **dst) {
-    run_container_t *ans = run_container_create();
-    run_container_andnot(src_1, src_2, ans);
-    uint8_t typecode_after;
-    *dst = convert_run_to_efficient_container_and_free(ans, &typecode_after);
-    return typecode_after;
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-int run_run_container_iandnot(run_container_t *src_1,
-                              const run_container_t *src_2, void **dst) {
-    // following Java impl as of June 2016 (dummy)
-    int ans = run_run_container_andnot(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
-}
-
-/*
- * dst is a valid array container and may be the same as src_1
- */
-
-void array_array_container_andnot(const array_container_t *src_1,
-                                  const array_container_t *src_2,
-                                  array_container_t *dst) {
-    array_container_andnot(src_1, src_2, dst);
-}
-
-/* inplace array-array andnot will always be able to reuse the space of
- * src_1 */
-void array_array_container_iandnot(array_container_t *src_1,
-                                   const array_container_t *src_2) {
-    array_container_andnot(src_1, src_2, src_1);
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially). Return value is
- * "dst is a bitset"
- */
-
-bool bitset_bitset_container_andnot(const bitset_container_t *src_1,
-                                    const bitset_container_t *src_2,
-                                    void **dst) {
-    bitset_container_t *ans = bitset_container_create();
-    int card = bitset_container_andnot(src_1, src_2, ans);
-    if (card <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(ans);
-        bitset_container_free(ans);
-        return false;  // not bitset
-    } else {
-        *dst = ans;
-        return true;
-    }
-}
-
-/* Compute the andnot of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     void **dst) {
-    int card = bitset_container_andnot(src_1, src_2, src_1);
-    if (card <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(src_1);
-        bitset_container_free(src_1);
-        return false;  // not bitset
-    } else {
-        *dst = src_1;
-        return true;
-    }
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_andnot.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_equal.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_equal.c"
-
-bool array_container_equal_bitset(array_container_t* container1,
-                                  bitset_container_t* container2) {
-    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
-        if (container2->cardinality != container1->cardinality) {
-            return false;
-        }
-    }
-    int32_t pos = 0;
-    for (int32_t i = 0; i < BITSET_CONTAINER_SIZE_IN_WORDS; ++i) {
-        uint64_t w = container2->array[i];
-        while (w != 0) {
-            uint64_t t = w & -w;
-            uint16_t r = i * 64 + __builtin_ctzll(w);
-            if (pos >= container1->cardinality) {
-                return false;
-            }
-            if (container1->array[pos] != r) {
-                return false;
-            }
-            ++pos;
-            w ^= t;
-        }
-    }
-    return (pos == container1->cardinality);
-}
-
-bool run_container_equals_array(run_container_t* container1,
-                                array_container_t* container2) {
-    if (run_container_cardinality(container1) != container2->cardinality)
-        return false;
-    int32_t pos = 0;
-    for (int i = 0; i < container1->n_runs; ++i) {
-        uint32_t run_start = container1->runs[i].value;
-        uint32_t le = container1->runs[i].length;
-
-        for (uint32_t j = run_start; j <= run_start + le; ++j) {
-            if (pos >= container2->cardinality) {
-                return false;
-            }
-            if (container2->array[pos] != j) {
-                return false;
-            }
-            ++pos;
-        }
-    }
-    return (pos == container2->cardinality);
-}
-
-bool run_container_equals_bitset(run_container_t* container1,
-                                 bitset_container_t* container2) {
-    if (container2->cardinality != BITSET_UNKNOWN_CARDINALITY) {
-        if (container2->cardinality != run_container_cardinality(container1)) {
-            return false;
-        }
-    } else {
-        int32_t card = bitset_container_compute_cardinality(
-            container2);  // modify container2?
-        if (card != run_container_cardinality(container1)) {
-            return false;
-        }
-    }
-    for (int i = 0; i < container1->n_runs; ++i) {
-        uint32_t run_start = container1->runs[i].value;
-        uint32_t le = container1->runs[i].length;
-        for (uint32_t j = run_start; j <= run_start + le; ++j) {
-            // todo: this code could be much faster
-            if (!bitset_container_contains(container2, j)) {
-                return false;
-            }
-        }
-    }
-    return true;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_equal.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_intersection.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_intersection.c"
-/*
- * mixed_intersection.c
- *
- */
-
-
-/* Compute the intersection of src_1 and src_2 and write the result to
- * dst.  */
-void array_bitset_container_intersection(const array_container_t *src_1,
-                                         const bitset_container_t *src_2,
-                                         array_container_t *dst) {
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
-    int32_t newcard = 0;  // dst could be src_1
-    const int32_t origcard = src_1->cardinality;
-    for (int i = 0; i < origcard; ++i) {
-        // could probably be vectorized
-        uint16_t key = src_1->array[i];
-        // next bit could be branchless
-        if (bitset_container_contains(src_2, key)) {
-            dst->array[newcard++] = key;
-        }
-    }
-    dst->cardinality = newcard;
-}
-
-/* Compute the intersection of src_1 and src_2 and write the result to
- * dst. It is allowed for dst to be equal to src_1. We assume that dst is a
- * valid container. */
-void array_run_container_intersection(const array_container_t *src_1,
-                                      const run_container_t *src_2,
-                                      array_container_t *dst) {
-    if (dst->capacity < src_1->cardinality)
-        array_container_grow(dst, src_1->cardinality, INT32_MAX, false);
-    if (src_2->n_runs == 0) {
-        return;
-    }
-    int32_t rlepos = 0;
-    int32_t arraypos = 0;
-    rle16_t rle = src_2->runs[rlepos];
-    int32_t newcard = 0;
-    while (arraypos < src_1->cardinality) {
-        const uint16_t arrayval = src_1->array[arraypos];
-        while (rle.value + rle.length <
-               arrayval) {  // this will frequently be false
-            ++rlepos;
-            if (rlepos == src_2->n_runs) {
-                dst->cardinality = newcard;
-                return;  // we are done
-            }
-            rle = src_2->runs[rlepos];
-        }
-        if (rle.value > arrayval) {
-            arraypos = advanceUntil(src_1->array, arraypos, src_1->cardinality,
-                                    rle.value);
-        } else {
-            dst->array[newcard] = arrayval;
-            newcard++;
-            arraypos++;
-        }
-    }
-    dst->cardinality = newcard;
-}
-
-/* Compute the intersection of src_1 and src_2 and write the result to
- * *dst. If the result is true then the result is a bitset_container_t
- * otherwise is a array_container_t.  */
-bool run_bitset_container_intersection(const run_container_t *src_1,
-                                       const bitset_container_t *src_2,
-                                       void **dst) {
-    int32_t card = run_container_cardinality(src_1);
-    if (card <= DEFAULT_MAX_SIZE) {
-        // result can only be an array (assuming that we never make a
-        // RunContainer)
-        if (card > src_2->cardinality) {
-            card = src_2->cardinality;
-        }
-        array_container_t *answer = array_container_create_given_capacity(card);
-        *dst = answer;
-        if (*dst == NULL) {
-            return false;
-        }
-        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-            rle16_t rle = src_1->runs[rlepos];
-            uint32_t endofrun = (uint32_t)rle.value + rle.length;
-            for (uint32_t runValue = rle.value; runValue <= endofrun;
-                 ++runValue) {
-                if (bitset_container_contains(src_2, runValue)) {
-                    answer->array[answer->cardinality++] = (uint16_t)runValue;
-                }
-            }
-        }
-        return false;
-    }
-    if (*dst == src_2) {  // we attempt in-place
-        bitset_container_t *answer = (bitset_container_t *)*dst;
-        uint32_t start = 0;
-        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-            const rle16_t rle = src_1->runs[rlepos];
-            uint32_t end = rle.value;
-            bitset_reset_range(src_2->array, start, end);
-
-            start = end + rle.length + 1;
-        }
-        bitset_reset_range(src_2->array, start, UINT32_C(1) << 16);
-        answer->cardinality = bitset_container_compute_cardinality(answer);
-        if (src_2->cardinality > DEFAULT_MAX_SIZE) {
-            return true;
-        } else {
-            array_container_t *newanswer = array_container_from_bitset(src_2);
-            if (newanswer == NULL) {
-                *dst = NULL;
-                return false;
-            }
-            *dst = newanswer;
-            return false;
-        }
-    } else {  // no inplace
-        // we expect the answer to be a bitmap (if we are lucky)
-        bitset_container_t *answer = bitset_container_clone(src_2);
-
-        *dst = answer;
-        if (answer == NULL) {
-            return true;
-        }
-        uint32_t start = 0;
-        for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-            const rle16_t rle = src_1->runs[rlepos];
-            uint32_t end = rle.value;
-            bitset_reset_range(answer->array, start, end);
-            start = end + rle.length + 1;
-        }
-        bitset_reset_range(answer->array, start, UINT32_C(1) << 16);
-        answer->cardinality = bitset_container_compute_cardinality(answer);
-
-        if (answer->cardinality > DEFAULT_MAX_SIZE) {
-            return true;
-        } else {
-            array_container_t *newanswer = array_container_from_bitset(answer);
-            bitset_container_free((bitset_container_t *)*dst);
-            if (newanswer == NULL) {
-                *dst = NULL;
-                return false;
-            }
-            *dst = newanswer;
-            return false;
-        }
-    }
-}
-
-/*
- * Compute the intersection between src_1 and src_2 and write the result
- * to *dst. If the return function is true, the result is a bitset_container_t
- * otherwise is a array_container_t.
- */
-bool bitset_bitset_container_intersection(const bitset_container_t *src_1,
-                                          const bitset_container_t *src_2,
-                                          void **dst) {
-    const int newCardinality = bitset_container_and_justcard(src_1, src_2);
-    if (newCardinality > DEFAULT_MAX_SIZE) {
-        *dst = bitset_container_create();
-        if (*dst != NULL) {
-            bitset_container_and_nocard(src_1, src_2,
-                                        (bitset_container_t *)*dst);
-            ((bitset_container_t *)*dst)->cardinality = newCardinality;
-        }
-        return true;  // it is a bitset
-    }
-    *dst = array_container_create_given_capacity(newCardinality);
-    if (*dst != NULL) {
-        ((array_container_t *)*dst)->cardinality = newCardinality;
-        bitset_extract_intersection_setbits_uint16(
-            ((bitset_container_t *)src_1)->array,
-            ((bitset_container_t *)src_2)->array,
-            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
-            0);
-    }
-    return false;  // not a bitset
-}
-
-bool bitset_bitset_container_intersection_inplace(
-    bitset_container_t *src_1, const bitset_container_t *src_2, void **dst) {
-    const int newCardinality = bitset_container_and_justcard(src_1, src_2);
-    if (newCardinality > DEFAULT_MAX_SIZE) {
-        *dst = src_1;
-        bitset_container_and_nocard(src_1, src_2, src_1);
-        ((bitset_container_t *)*dst)->cardinality = newCardinality;
-        return true;  // it is a bitset
-    }
-    *dst = array_container_create_given_capacity(newCardinality);
-    if (*dst != NULL) {
-        ((array_container_t *)*dst)->cardinality = newCardinality;
-        bitset_extract_intersection_setbits_uint16(
-            ((bitset_container_t *)src_1)->array,
-            ((bitset_container_t *)src_2)->array,
-            BITSET_CONTAINER_SIZE_IN_WORDS, ((array_container_t *)*dst)->array,
-            0);
-    }
-    return false;  // not a bitset
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_intersection.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_negation.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_negation.c"
-/*
- * mixed_negation.c
- *
- */
-
-#include <assert.h>
-#include <string.h>
-
-
-// TODO: make simplified and optimized negation code across
-// the full range.
-
-/* Negation across the entire range of the container.
- * Compute the  negation of src  and write the result
- * to *dst. The complement of a
- * sufficiently sparse set will always be dense and a hence a bitmap
-' * We assume that dst is pre-allocated and a valid bitset container
- * There can be no in-place version.
- */
-void array_container_negation(const array_container_t *src,
-                              bitset_container_t *dst) {
-    uint64_t card = UINT64_C(1 << 16);
-    bitset_container_set_all(dst);
-
-    dst->cardinality =
-        bitset_clear_list(dst->array, card, src->array, src->cardinality);
-}
-
-/* Negation across the entire range of the container
- * Compute the  negation of src  and write the result
- * to *dst.  A true return value indicates a bitset result,
- * otherwise the result is an array container.
- *  We assume that dst is not pre-allocated. In
- * case of failure, *dst will be NULL.
- */
-bool bitset_container_negation(const bitset_container_t *src, void **dst) {
-    return bitset_container_negation_range(src, 0, (1 << 16), dst);
-}
-
-/* inplace version */
-/*
- * Same as bitset_container_negation except that if the output is to
- * be a
- * bitset_container_t, then src is modified and no allocation is made.
- * If the output is to be an array_container_t, then caller is responsible
- * to free the container.
- * In all cases, the result is in *dst.
- */
-bool bitset_container_negation_inplace(bitset_container_t *src, void **dst) {
-    return bitset_container_negation_range_inplace(src, 0, (1 << 16), dst);
-}
-
-/* Negation across the entire range of container
- * Compute the  negation of src  and write the result
- * to *dst.  Return values are the *_TYPECODES as defined * in containers.h
- *  We assume that dst is not pre-allocated. In
- * case of failure, *dst will be NULL.
- */
-int run_container_negation(const run_container_t *src, void **dst) {
-    return run_container_negation_range(src, 0, (1 << 16), dst);
-}
-
-/*
- * Same as run_container_negation except that if the output is to
- * be a
- * run_container_t, and has the capacity to hold the result,
- * then src is modified and no allocation is made.
- * In all cases, the result is in *dst.
- */
-int run_container_negation_inplace(run_container_t *src, void **dst) {
-    return run_container_negation_range_inplace(src, 0, (1 << 16), dst);
-}
-
-/* Negation across a range of the container.
- * Compute the  negation of src  and write the result
- * to *dst. Returns true if the result is a bitset container
- * and false for an array container.  *dst is not preallocated.
- */
-bool array_container_negation_range(const array_container_t *src,
-                                    const int range_start, const int range_end,
-                                    void **dst) {
-    /* close port of the Java implementation */
-    if (range_start >= range_end) {
-        *dst = array_container_clone(src);
-        return false;
-    }
-
-    int32_t start_index =
-        binarySearch(src->array, src->cardinality, (uint16_t)range_start);
-    if (start_index < 0) start_index = -start_index - 1;
-
-    int32_t last_index =
-        binarySearch(src->array, src->cardinality, (uint16_t)(range_end - 1));
-    if (last_index < 0) last_index = -last_index - 2;
-
-    const int32_t current_values_in_range = last_index - start_index + 1;
-    const int32_t span_to_be_flipped = range_end - range_start;
-    const int32_t new_values_in_range =
-        span_to_be_flipped - current_values_in_range;
-    const int32_t cardinality_change =
-        new_values_in_range - current_values_in_range;
-    const int32_t new_cardinality = src->cardinality + cardinality_change;
-
-    if (new_cardinality > DEFAULT_MAX_SIZE) {
-        bitset_container_t *temp = bitset_container_from_array(src);
-        bitset_flip_range(temp->array, (uint32_t)range_start,
-                          (uint32_t)range_end);
-        temp->cardinality = new_cardinality;
-        *dst = temp;
-        return true;
-    }
-
-    array_container_t *arr =
-        array_container_create_given_capacity(new_cardinality);
-    *dst = (void *)arr;
-    // copy stuff before the active area
-    memcpy(arr->array, src->array, start_index * sizeof(uint16_t));
-
-    // work on the range
-    int32_t out_pos = start_index, in_pos = start_index;
-    int32_t val_in_range = range_start;
-    for (; val_in_range < range_end && in_pos <= last_index; ++val_in_range) {
-        if ((uint16_t)val_in_range != src->array[in_pos]) {
-            arr->array[out_pos++] = (uint16_t)val_in_range;
-        } else {
-            ++in_pos;
-        }
-    }
-    for (; val_in_range < range_end; ++val_in_range)
-        arr->array[out_pos++] = (uint16_t)val_in_range;
-
-    // content after the active range
-    memcpy(arr->array + out_pos, src->array + (last_index + 1),
-           (src->cardinality - (last_index + 1)) * sizeof(uint16_t));
-    arr->cardinality = new_cardinality;
-    return false;
-}
-
-/* Even when the result would fit, it is unclear how to make an
- * inplace version without inefficient copying.
- */
-
-bool array_container_negation_range_inplace(array_container_t *src,
-                                            const int range_start,
-                                            const int range_end, void **dst) {
-    bool ans = array_container_negation_range(src, range_start, range_end, dst);
-    // TODO : try a real inplace version
-    array_container_free(src);
-    return ans;
-}
-
-/* Negation across a range of the container
- * Compute the  negation of src  and write the result
- * to *dst.  A true return value indicates a bitset result,
- * otherwise the result is an array container.
- *  We assume that dst is not pre-allocated. In
- * case of failure, *dst will be NULL.
- */
-bool bitset_container_negation_range(const bitset_container_t *src,
-                                     const int range_start, const int range_end,
-                                     void **dst) {
-    // TODO maybe consider density-based estimate
-    // and sometimes build result directly as array, with
-    // conversion back to bitset if wrong.  Or determine
-    // actual result cardinality, then go directly for the known final cont.
-
-    // keep computation using bitsets as long as possible.
-    bitset_container_t *t = bitset_container_clone(src);
-    bitset_flip_range(t->array, (uint32_t)range_start, (uint32_t)range_end);
-    t->cardinality = bitset_container_compute_cardinality(t);
-
-    if (t->cardinality > DEFAULT_MAX_SIZE) {
-        *dst = t;
-        return true;
-    } else {
-        *dst = array_container_from_bitset(t);
-        bitset_container_free(t);
-        return false;
-    }
-}
-
-/* inplace version */
-/*
- * Same as bitset_container_negation except that if the output is to
- * be a
- * bitset_container_t, then src is modified and no allocation is made.
- * If the output is to be an array_container_t, then caller is responsible
- * to free the container.
- * In all cases, the result is in *dst.
- */
-bool bitset_container_negation_range_inplace(bitset_container_t *src,
-                                             const int range_start,
-                                             const int range_end, void **dst) {
-    bitset_flip_range(src->array, (uint32_t)range_start, (uint32_t)range_end);
-    src->cardinality = bitset_container_compute_cardinality(src);
-    if (src->cardinality > DEFAULT_MAX_SIZE) {
-        *dst = src;
-        return true;
-    }
-    *dst = array_container_from_bitset(src);
-    bitset_container_free(src);
-    return false;
-}
-
-/* Negation across a range of container
- * Compute the  negation of src  and write the result
- * to *dst. Return values are the *_TYPECODES as defined * in containers.h
- *  We assume that dst is not pre-allocated. In
- * case of failure, *dst will be NULL.
- */
-int run_container_negation_range(const run_container_t *src,
-                                 const int range_start, const int range_end,
-                                 void **dst) {
-    uint8_t return_typecode;
-
-    // follows the Java implementation
-    if (range_end <= range_start) {
-        *dst = run_container_clone(src);
-        return RUN_CONTAINER_TYPE_CODE;
-    }
-
-    run_container_t *ans = run_container_create_given_capacity(
-        src->n_runs + 1);  // src->n_runs + 1);
-    int k = 0;
-    for (; k < src->n_runs && src->runs[k].value < range_start; ++k) {
-        ans->runs[k] = src->runs[k];
-        ans->n_runs++;
-    }
-
-    run_container_smart_append_exclusive(
-        ans, (uint16_t)range_start, (uint16_t)(range_end - range_start - 1));
-
-    for (; k < src->n_runs; ++k) {
-        run_container_smart_append_exclusive(ans, src->runs[k].value,
-                                             src->runs[k].length);
-    }
-
-    *dst = convert_run_to_efficient_container(ans, &return_typecode);
-    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
-
-    return return_typecode;
-}
-
-/*
- * Same as run_container_negation except that if the output is to
- * be a
- * run_container_t, and has the capacity to hold the result,
- * then src is modified and no allocation is made.
- * In all cases, the result is in *dst.
- */
-int run_container_negation_range_inplace(run_container_t *src,
-                                         const int range_start,
-                                         const int range_end, void **dst) {
-    uint8_t return_typecode;
-
-    if (range_end <= range_start) {
-        *dst = src;
-        return RUN_CONTAINER_TYPE_CODE;
-    }
-
-    // TODO: efficient special case when range is 0 to 65535 inclusive
-
-    if (src->capacity == src->n_runs) {
-        // no excess room.  More checking to see if result can fit
-        bool last_val_before_range = false;
-        bool first_val_in_range = false;
-        bool last_val_in_range = false;
-        bool first_val_past_range = false;
-
-        if (range_start > 0)
-            last_val_before_range =
-                run_container_contains(src, (uint16_t)(range_start - 1));
-        first_val_in_range = run_container_contains(src, (uint16_t)range_start);
-
-        if (last_val_before_range == first_val_in_range) {
-            last_val_in_range =
-                run_container_contains(src, (uint16_t)(range_end - 1));
-            if (range_end != 0x10000)
-                first_val_past_range =
-                    run_container_contains(src, (uint16_t)range_end);
-
-            if (last_val_in_range ==
-                first_val_past_range) {  // no space for inplace
-                int ans = run_container_negation_range(src, range_start,
-                                                       range_end, dst);
-                run_container_free(src);
-                return ans;
-            }
-        }
-    }
-    // all other cases: result will fit
-
-    run_container_t *ans = src;
-    int my_nbr_runs = src->n_runs;
-
-    ans->n_runs = 0;
-    int k = 0;
-    for (; (k < my_nbr_runs) && (src->runs[k].value < range_start); ++k) {
-        // ans->runs[k] = src->runs[k]; (would be self-copy)
-        ans->n_runs++;
-    }
-
-    // as with Java implementation, use locals to give self a buffer of depth 1
-    rle16_t buffered = (rle16_t){.value = (uint16_t)0, .length = (uint16_t)0};
-    rle16_t next = buffered;
-    if (k < my_nbr_runs) buffered = src->runs[k];
-
-    run_container_smart_append_exclusive(
-        ans, (uint16_t)range_start, (uint16_t)(range_end - range_start - 1));
-
-    for (; k < my_nbr_runs; ++k) {
-        if (k + 1 < my_nbr_runs) next = src->runs[k + 1];
-
-        run_container_smart_append_exclusive(ans, buffered.value,
-                                             buffered.length);
-        buffered = next;
-    }
-
-    *dst = convert_run_to_efficient_container(ans, &return_typecode);
-    if (return_typecode != RUN_CONTAINER_TYPE_CODE) run_container_free(ans);
-
-    return return_typecode;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_negation.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_union.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_union.c"
-/*
- * mixed_union.c
- *
- */
-
-#include <assert.h>
-#include <string.h>
-
-
-/* Compute the union of src_1 and src_2 and write the result to
- * dst.  */
-void array_bitset_container_union(const array_container_t *src_1,
-                                  const bitset_container_t *src_2,
-                                  bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    dst->cardinality = bitset_set_list_withcard(
-        dst->array, dst->cardinality, src_1->array, src_1->cardinality);
-}
-
-/* Compute the union of src_1 and src_2 and write the result to
- * dst. It is allowed for src_2 to be dst.  This version does not
- * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY). */
-void array_bitset_container_lazy_union(const array_container_t *src_1,
-                                       const bitset_container_t *src_2,
-                                       bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    bitset_set_list(dst->array, src_1->array, src_1->cardinality);
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
-}
-
-void run_bitset_container_union(const run_container_t *src_1,
-                                const bitset_container_t *src_2,
-                                bitset_container_t *dst) {
-    assert(!run_container_is_full(src_1));  // catch this case upstream
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_set_lenrange(dst->array, rle.value, rle.length);
-    }
-    dst->cardinality = bitset_container_compute_cardinality(dst);
-}
-
-void run_bitset_container_lazy_union(const run_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     bitset_container_t *dst) {
-    assert(!run_container_is_full(src_1));  // catch this case upstream
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_set_lenrange(dst->array, rle.value, rle.length);
-    }
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
-}
-
-// why do we leave the result as a run container??
-void array_run_container_union(const array_container_t *src_1,
-                               const run_container_t *src_2,
-                               run_container_t *dst) {
-    if (run_container_is_full(src_2)) {
-        run_container_copy(src_2, dst);
-        return;
-    }
-    // TODO: see whether the "2*" is spurious
-    run_container_grow(dst, 2 * (src_1->cardinality + src_2->n_runs), false);
-    int32_t rlepos = 0;
-    int32_t arraypos = 0;
-    rle16_t previousrle;
-    if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
-        previousrle = run_container_append_first(dst, src_2->runs[rlepos]);
-        rlepos++;
-    } else {
-        previousrle =
-            run_container_append_value_first(dst, src_1->array[arraypos]);
-        arraypos++;
-    }
-    while ((rlepos < src_2->n_runs) && (arraypos < src_1->cardinality)) {
-        if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
-            run_container_append(dst, src_2->runs[rlepos], &previousrle);
-            rlepos++;
-        } else {
-            run_container_append_value(dst, src_1->array[arraypos],
-                                       &previousrle);
-            arraypos++;
-        }
-    }
-    if (arraypos < src_1->cardinality) {
-        while (arraypos < src_1->cardinality) {
-            run_container_append_value(dst, src_1->array[arraypos],
-                                       &previousrle);
-            arraypos++;
-        }
-    } else {
-        while (rlepos < src_2->n_runs) {
-            run_container_append(dst, src_2->runs[rlepos], &previousrle);
-            rlepos++;
-        }
-    }
-}
-
-void array_run_container_inplace_union(const array_container_t *src_1,
-                                       run_container_t *src_2) {
-    if (run_container_is_full(src_2)) {
-        return;
-    }
-    const int32_t maxoutput = src_1->cardinality + src_2->n_runs;
-    const int32_t neededcapacity = maxoutput + src_2->n_runs;
-    if (src_2->capacity < neededcapacity)
-        run_container_grow(src_2, neededcapacity, true);
-    memmove(src_2->runs + maxoutput, src_2->runs,
-            src_2->n_runs * sizeof(rle16_t));
-    rle16_t *inputsrc2 = src_2->runs + maxoutput;
-    int32_t rlepos = 0;
-    int32_t arraypos = 0;
-    int src2nruns = src_2->n_runs;
-    src_2->n_runs = 0;
-
-    rle16_t previousrle;
-
-    if (inputsrc2[rlepos].value <= src_1->array[arraypos]) {
-        previousrle = run_container_append_first(src_2, inputsrc2[rlepos]);
-        rlepos++;
-    } else {
-        previousrle =
-            run_container_append_value_first(src_2, src_1->array[arraypos]);
-        arraypos++;
-    }
-
-    while ((rlepos < src2nruns) && (arraypos < src_1->cardinality)) {
-        if (inputsrc2[rlepos].value <= src_1->array[arraypos]) {
-            run_container_append(src_2, inputsrc2[rlepos], &previousrle);
-            rlepos++;
-        } else {
-            run_container_append_value(src_2, src_1->array[arraypos],
-                                       &previousrle);
-            arraypos++;
-        }
-    }
-    if (arraypos < src_1->cardinality) {
-        while (arraypos < src_1->cardinality) {
-            run_container_append_value(src_2, src_1->array[arraypos],
-                                       &previousrle);
-            arraypos++;
-        }
-    } else {
-        while (rlepos < src2nruns) {
-            run_container_append(src_2, inputsrc2[rlepos], &previousrle);
-            rlepos++;
-        }
-    }
-}
-
-bool array_array_container_union(const array_container_t *src_1,
-                                 const array_container_t *src_2, void **dst) {
-    int totalCardinality = src_1->cardinality + src_2->cardinality;
-    if (totalCardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        if (*dst != NULL)
-            array_container_union(src_1, src_2, (array_container_t *)*dst);
-        return false;  // not a bitset
-    }
-    *dst = bitset_container_create();
-    bool returnval = true;  // expect a bitset
-    if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
-        ourbitset->cardinality =
-            bitset_set_list_withcard(ourbitset->array, src_1->cardinality,
-                                     src_2->array, src_2->cardinality);
-        if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
-            // need to convert!
-            *dst = array_container_from_bitset(ourbitset);
-            bitset_container_free(ourbitset);
-            returnval = false;  // not going to be a bitset
-        }
-    }
-    return returnval;
-}
-
-bool array_array_container_lazy_union(const array_container_t *src_1,
-                                      const array_container_t *src_2,
-                                      void **dst) {
-    int totalCardinality = src_1->cardinality + src_2->cardinality;
-    if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        if (*dst != NULL)
-            array_container_union(src_1, src_2, (array_container_t *)*dst);
-        return false;  // not a bitset
-    }
-    *dst = bitset_container_create();
-    bool returnval = true;  // expect a bitset
-    if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
-        bitset_set_list(ourbitset->array, src_1->array, src_1->cardinality);
-        bitset_set_list(ourbitset->array, src_2->array, src_2->cardinality);
-        ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
-    }
-    return returnval;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_union.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/mixed_xor.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/mixed_xor.c"
-/*
- * mixed_xor.c
- */
-
-#include <assert.h>
-#include <string.h>
-
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially).
- * Result is true iff dst is a bitset  */
-bool array_bitset_container_xor(const array_container_t *src_1,
-                                const bitset_container_t *src_2, void **dst) {
-    bitset_container_t *result = bitset_container_create();
-    bitset_container_copy(src_2, result);
-    result->cardinality = bitset_flip_list_withcard(
-        result->array, result->cardinality, src_1->array, src_1->cardinality);
-
-    // do required type conversions.
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;  // not bitset
-    }
-    *dst = result;
-    return true;  // bitset
-}
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. It is allowed for src_2 to be dst.  This version does not
- * update the cardinality of dst (it is set to BITSET_UNKNOWN_CARDINALITY).
- */
-
-void array_bitset_container_lazy_xor(const array_container_t *src_1,
-                                     const bitset_container_t *src_2,
-                                     bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    bitset_flip_list(dst->array, src_1->array, src_1->cardinality);
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
-}
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool run_bitset_container_xor(const run_container_t *src_1,
-                              const bitset_container_t *src_2, void **dst) {
-    bitset_container_t *result = bitset_container_create();
-
-    bitset_container_copy(src_2, result);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(result->array, rle.value,
-                          rle.value + rle.length + UINT32_C(1));
-    }
-    result->cardinality = bitset_container_compute_cardinality(result);
-
-    if (result->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(result);
-        bitset_container_free(result);
-        return false;  // not bitset
-    }
-    *dst = result;
-    return true;  // bitset
-}
-
-/* lazy xor.  Dst is initialized and may be equal to src_2.
- *  Result is left as a bitset container, even if actual
- *  cardinality would dictate an array container.
- */
-
-void run_bitset_container_lazy_xor(const run_container_t *src_1,
-                                   const bitset_container_t *src_2,
-                                   bitset_container_t *dst) {
-    if (src_2 != dst) bitset_container_copy(src_2, dst);
-    for (int32_t rlepos = 0; rlepos < src_1->n_runs; ++rlepos) {
-        rle16_t rle = src_1->runs[rlepos];
-        bitset_flip_range(dst->array, rle.value,
-                          rle.value + rle.length + UINT32_C(1));
-    }
-    dst->cardinality = BITSET_UNKNOWN_CARDINALITY;
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int array_run_container_xor(const array_container_t *src_1,
-                            const run_container_t *src_2, void **dst) {
-    // semi following Java XOR implementation as of May 2016
-    // the C OR implementation works quite differently and can return a run
-    // container
-    // TODO could optimize for full run containers.
-
-    // use of lazy following Java impl.
-    const int arbitrary_threshold = 32;
-    if (src_1->cardinality < arbitrary_threshold) {
-        run_container_t *ans = run_container_create();
-        array_run_container_lazy_xor(src_1, src_2, ans);  // keeps runs.
-        uint8_t typecode_after;
-        *dst =
-            convert_run_to_efficient_container_and_free(ans, &typecode_after);
-        return typecode_after;
-    }
-
-    int card = run_container_cardinality(src_2);
-    if (card <= DEFAULT_MAX_SIZE) {
-        // Java implementation works with the array, xoring the run elements via
-        // iterator
-        array_container_t *temp = array_container_from_run(src_2);
-        bool ret_is_bitset = array_array_container_xor(temp, src_1, dst);
-        array_container_free(temp);
-        return ret_is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                             : ARRAY_CONTAINER_TYPE_CODE;
-
-    } else {  // guess that it will end up as a bitset
-        bitset_container_t *result = bitset_container_from_run(src_2);
-        bool is_bitset = bitset_array_container_ixor(result, src_1, dst);
-        // any necessary type conversion has been done by the ixor
-        int retval = (is_bitset ? BITSET_CONTAINER_TYPE_CODE
-                                : ARRAY_CONTAINER_TYPE_CODE);
-        return retval;
-    }
-}
-
-/* Dst is a valid run container. (Can it be src_2? Let's say not.)
- * Leaves result as run container, even if other options are
- * smaller.
- */
-
-void array_run_container_lazy_xor(const array_container_t *src_1,
-                                  const run_container_t *src_2,
-                                  run_container_t *dst) {
-    run_container_grow(dst, src_1->cardinality + src_2->n_runs, false);
-    int32_t rlepos = 0;
-    int32_t arraypos = 0;
-    dst->n_runs = 0;
-
-    while ((rlepos < src_2->n_runs) && (arraypos < src_1->cardinality)) {
-        if (src_2->runs[rlepos].value <= src_1->array[arraypos]) {
-            run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
-                                                 src_2->runs[rlepos].length);
-            rlepos++;
-        } else {
-            run_container_smart_append_exclusive(dst, src_1->array[arraypos],
-                                                 0);
-            arraypos++;
-        }
-    }
-    while (arraypos < src_1->cardinality) {
-        run_container_smart_append_exclusive(dst, src_1->array[arraypos], 0);
-        arraypos++;
-    }
-    while (rlepos < src_2->n_runs) {
-        run_container_smart_append_exclusive(dst, src_2->runs[rlepos].value,
-                                             src_2->runs[rlepos].length);
-        rlepos++;
-    }
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int run_run_container_xor(const run_container_t *src_1,
-                          const run_container_t *src_2, void **dst) {
-    run_container_t *ans = run_container_create();
-    run_container_xor(src_1, src_2, ans);
-    uint8_t typecode_after;
-    *dst = convert_run_to_efficient_container_and_free(ans, &typecode_after);
-    return typecode_after;
-}
-
-/*
- * Java implementation (as of May 2016) for array_run, run_run
- * and  bitset_run don't do anything different for inplace.
- * Could adopt the mixed_union.c approach instead (ie, using
- * smart_append_exclusive)
- *
- */
-
-bool array_array_container_xor(const array_container_t *src_1,
-                               const array_container_t *src_2, void **dst) {
-    int totalCardinality =
-        src_1->cardinality + src_2->cardinality;  // upper bound
-    if (totalCardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        array_container_xor(src_1, src_2, (array_container_t *)*dst);
-        return false;  // not a bitset
-    }
-    *dst = bitset_container_from_array(src_1);
-    bool returnval = true;  // expect a bitset
-    bitset_container_t *ourbitset = (bitset_container_t *)*dst;
-    ourbitset->cardinality = bitset_flip_list_withcard(
-        ourbitset->array, src_1->cardinality, src_2->array, src_2->cardinality);
-    if (ourbitset->cardinality <= DEFAULT_MAX_SIZE) {
-        // need to convert!
-        *dst = array_container_from_bitset(ourbitset);
-        bitset_container_free(ourbitset);
-        returnval = false;  // not going to be a bitset
-    }
-
-    return returnval;
-}
-
-bool array_array_container_lazy_xor(const array_container_t *src_1,
-                                    const array_container_t *src_2,
-                                    void **dst) {
-    int totalCardinality = src_1->cardinality + src_2->cardinality;
-    // upper bound, but probably poor estimate for xor
-    if (totalCardinality <= ARRAY_LAZY_LOWERBOUND) {
-        *dst = array_container_create_given_capacity(totalCardinality);
-        if (*dst != NULL)
-            array_container_xor(src_1, src_2, (array_container_t *)*dst);
-        return false;  // not a bitset
-    }
-    *dst = bitset_container_from_array(src_1);
-    bool returnval = true;  // expect a bitset (maybe, for XOR??)
-    if (*dst != NULL) {
-        bitset_container_t *ourbitset = (bitset_container_t *)*dst;
-        bitset_flip_list(ourbitset->array, src_2->array, src_2->cardinality);
-        ourbitset->cardinality = BITSET_UNKNOWN_CARDINALITY;
-    }
-    return returnval;
-}
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially). Return value is
- * "dst is a bitset"
- */
-
-bool bitset_bitset_container_xor(const bitset_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
-    bitset_container_t *ans = bitset_container_create();
-    int card = bitset_container_xor(src_1, src_2, ans);
-    if (card <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(ans);
-        bitset_container_free(ans);
-        return false;  // not bitset
-    } else {
-        *dst = ans;
-        return true;
-    }
-}
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst (which has no container initially).  It will modify src_1
- * to be dst if the result is a bitset.  Otherwise, it will
- * free src_1 and dst will be a new array container.  In both
- * cases, the caller is responsible for deallocating dst.
- * Returns true iff dst is a bitset  */
-
-bool bitset_array_container_ixor(bitset_container_t *src_1,
-                                 const array_container_t *src_2, void **dst) {
-    *dst = src_1;
-    src_1->cardinality = bitset_flip_list_withcard(
-        src_1->array, src_1->cardinality, src_2->array, src_2->cardinality);
-
-    if (src_1->cardinality <= DEFAULT_MAX_SIZE) {
-        *dst = array_container_from_bitset(src_1);
-        bitset_container_free(src_1);
-        return false;  // not bitset
-    } else
-        return true;
-}
-
-/* a bunch of in-place, some of which may not *really* be inplace.
- * TODO: write actual inplace routine if efficiency warrants it
- * Anything inplace with a bitset is a good candidate
- */
-
-bool bitset_bitset_container_ixor(bitset_container_t *src_1,
-                                  const bitset_container_t *src_2, void **dst) {
-    bool ans = bitset_bitset_container_xor(src_1, src_2, dst);
-    bitset_container_free(src_1);
-    return ans;
-}
-
-bool array_bitset_container_ixor(array_container_t *src_1,
-                                 const bitset_container_t *src_2, void **dst) {
-    bool ans = array_bitset_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
-}
-
-/* Compute the xor of src_1 and src_2 and write the result to
- * dst. Result may be either a bitset or an array container
- * (returns "result is bitset"). dst does not initially have
- * any container, but becomes either a bitset container (return
- * result true) or an array container.
- */
-
-bool run_bitset_container_ixor(run_container_t *src_1,
-                               const bitset_container_t *src_2, void **dst) {
-    bool ans = run_bitset_container_xor(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
-}
-
-bool bitset_run_container_ixor(bitset_container_t *src_1,
-                               const run_container_t *src_2, void **dst) {
-    bool ans = run_bitset_container_xor(src_2, src_1, dst);
-    bitset_container_free(src_1);
-    return ans;
-}
-
-/* dst does not indicate a valid container initially.  Eventually it
- * can become any kind of container.
- */
-
-int array_run_container_ixor(array_container_t *src_1,
-                             const run_container_t *src_2, void **dst) {
-    int ans = array_run_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
-}
-
-int run_array_container_ixor(run_container_t *src_1,
-                             const array_container_t *src_2, void **dst) {
-    int ans = array_run_container_xor(src_2, src_1, dst);
-    run_container_free(src_1);
-    return ans;
-}
-
-bool array_array_container_ixor(array_container_t *src_1,
-                                const array_container_t *src_2, void **dst) {
-    bool ans = array_array_container_xor(src_1, src_2, dst);
-    array_container_free(src_1);
-    return ans;
-}
-
-int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
-                           void **dst) {
-    int ans = run_run_container_xor(src_1, src_2, dst);
-    run_container_free(src_1);
-    return ans;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/mixed_xor.c */
-/* begin file /Users/saulius/repos/CRoaring/src/containers/run.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/containers/run.c"
-#include <stdio.h>
-#include <stdlib.h>
-
-#ifdef IS_X64
-#include <x86intrin.h>
-#endif
-
-extern inline int32_t interleavedBinarySearch(const rle16_t *array,
-                                      int32_t lenarray, uint16_t ikey);
-extern inline bool run_container_contains(const run_container_t *run,
-                                           uint16_t pos);
-extern bool run_container_is_full(const run_container_t *run);
-extern bool run_container_nonzero_cardinality(const run_container_t *r);
-extern void run_container_clear(run_container_t *run);
-extern int32_t run_container_serialized_size_in_bytes(int32_t num_runs);
-extern run_container_t *run_container_create_range(uint32_t start,
-                                                   uint32_t stop);
-
-bool run_container_add(run_container_t *run, uint16_t pos) {
-    int32_t index = interleavedBinarySearch(run->runs, run->n_runs, pos);
-    if (index >= 0) return false;  // already there
-    index = -index - 2;            // points to preceding value, possibly -1
-    if (index >= 0) {              // possible match
-        int32_t offset = pos - run->runs[index].value;
-        int32_t le = run->runs[index].length;
-        if (offset <= le) return false;  // already there
-        if (offset == le + 1) {
-            // we may need to fuse
-            if (index + 1 < run->n_runs) {
-                if (run->runs[index + 1].value == pos + 1) {
-                    // indeed fusion is needed
-                    run->runs[index].length = run->runs[index + 1].value +
-                                              run->runs[index + 1].length -
-                                              run->runs[index].value;
-                    recoverRoomAtIndex(run, index + 1);
-                    return true;
-                }
-            }
-            run->runs[index].length++;
-            return true;
-        }
-        if (index + 1 < run->n_runs) {
-            // we may need to fuse
-            if (run->runs[index + 1].value == pos + 1) {
-                // indeed fusion is needed
-                run->runs[index + 1].value = pos;
-                run->runs[index + 1].length = run->runs[index + 1].length + 1;
-                return true;
-            }
-        }
-    }
-    if (index == -1) {
-        // we may need to extend the first run
-        if (0 < run->n_runs) {
-            if (run->runs[0].value == pos + 1) {
-                run->runs[0].length++;
-                run->runs[0].value--;
-                return true;
-            }
-        }
-    }
-    makeRoomAtIndex(run, index + 1);
-    run->runs[index + 1].value = pos;
-    run->runs[index + 1].length = 0;
-    return true;
-}
-
-/* Create a new run container. Return NULL in case of failure. */
-run_container_t *run_container_create_given_capacity(int32_t size) {
-    run_container_t *run;
-    /* Allocate the run container itself. */
-    if ((run = (run_container_t *)malloc(sizeof(run_container_t))) == NULL) {
-        return NULL;
-    }
-    if ((run->runs = (rle16_t *)malloc(sizeof(rle16_t) * size)) == NULL) {
-        free(run);
-        return NULL;
-    }
-    run->capacity = size;
-    run->n_runs = 0;
-    return run;
-}
-
-/* Create a new run container. Return NULL in case of failure. */
-run_container_t *run_container_create(void) {
-    return run_container_create_given_capacity(RUN_DEFAULT_INIT_SIZE);
-}
-
-run_container_t *run_container_clone(const run_container_t *src) {
-    run_container_t *run = run_container_create_given_capacity(src->capacity);
-    if (run == NULL) return NULL;
-    run->capacity = src->capacity;
-    run->n_runs = src->n_runs;
-    memcpy(run->runs, src->runs, src->n_runs * sizeof(rle16_t));
-    return run;
-}
-
-/* Free memory. */
-void run_container_free(run_container_t *run) {
-    free(run->runs);
-    run->runs = NULL;  // pedantic
-    free(run);
-}
-
-#ifdef USEAVX
-
-/* Get the cardinality of `run'. Requires an actual computation. */
-int run_container_cardinality(const run_container_t *run) {
-    const int32_t n_runs = run->n_runs;
-    const rle16_t *runs = run->runs;
-
-    /* by initializing with n_runs, we omit counting the +1 for each pair. */
-    int sum = n_runs;
-    int32_t k = 0;
-    const int32_t step = sizeof(__m256i) / sizeof(rle16_t);
-    if (n_runs > step) {
-        __m256i total = _mm256_setzero_si256();
-        for (; k + step <= n_runs; k += step) {
-            __m256i ymm1 = _mm256_lddqu_si256((const __m256i *)(runs + k));
-            __m256i justlengths = _mm256_srli_epi32(ymm1, 16);
-            total = _mm256_add_epi32(total, justlengths);
-        }
-        // a store might be faster than extract?
-        uint32_t buffer[sizeof(__m256i) / sizeof(rle16_t)];
-        _mm256_store_si256((__m256i *)buffer, total);
-        sum += (buffer[0] + buffer[1]) + (buffer[2] + buffer[3]) +
-               (buffer[4] + buffer[5]) + (buffer[6] + buffer[7]);
-    }
-    for (; k < n_runs; ++k) {
-        sum += runs[k].length;
-    }
-
-    return sum;
-}
-
-#else
-
-/* Get the cardinality of `run'. Requires an actual computation. */
-int run_container_cardinality(const run_container_t *run) {
-    const int32_t n_runs = run->n_runs;
-    const rle16_t *runs = run->runs;
-
-    /* by initializing with n_runs, we omit counting the +1 for each pair. */
-    int sum = n_runs;
-    for (int k = 0; k < n_runs; ++k) {
-        sum += runs[k].length;
-    }
-
-    return sum;
-}
-#endif
-
-void run_container_grow(run_container_t *run, int32_t min, bool copy) {
-    int32_t newCapacity =
-        (run->capacity == 0)
-            ? RUN_DEFAULT_INIT_SIZE
-            : run->capacity < 64 ? run->capacity * 2
-                                 : run->capacity < 1024 ? run->capacity * 3 / 2
-                                                        : run->capacity * 5 / 4;
-    if (newCapacity < min) newCapacity = min;
-    run->capacity = newCapacity;
-    assert(run->capacity >= min);
-    if (copy) {
-        rle16_t *oldruns = run->runs;
-        run->runs =
-            (rle16_t *)realloc(oldruns, run->capacity * sizeof(rle16_t));
-        if (run->runs == NULL) free(oldruns);
-    } else {
-        free(run->runs);
-        run->runs = (rle16_t *)malloc(run->capacity * sizeof(rle16_t));
-    }
-    // TODO: handle the case where realloc fails
-    assert(run->runs != NULL);
-}
-
-/* copy one container into another */
-void run_container_copy(const run_container_t *src, run_container_t *dst) {
-    const int32_t n_runs = src->n_runs;
-    if (src->n_runs > dst->capacity) {
-        run_container_grow(dst, n_runs, false);
-    }
-    dst->n_runs = n_runs;
-    memcpy(dst->runs, src->runs, sizeof(rle16_t) * n_runs);
-}
-
-/* Compute the union of `src_1' and `src_2' and write the result to `dst'
- * It is assumed that `dst' is distinct from both `src_1' and `src_2'. */
-void run_container_union(const run_container_t *src_1,
-                         const run_container_t *src_2, run_container_t *dst) {
-    // TODO: this could be a lot more efficient
-
-    // we start out with inexpensive checks
-    const bool if1 = run_container_is_full(src_1);
-    const bool if2 = run_container_is_full(src_2);
-    if (if1 || if2) {
-        if (if1) {
-            run_container_copy(src_1, dst);
-            return;
-        }
-        if (if2) {
-            run_container_copy(src_2, dst);
-            return;
-        }
-    }
-    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
-    if (dst->capacity < neededcapacity)
-        run_container_grow(dst, neededcapacity, false);
-    dst->n_runs = 0;
-    int32_t rlepos = 0;
-    int32_t xrlepos = 0;
-
-    rle16_t previousrle;
-    if (src_1->runs[rlepos].value <= src_2->runs[xrlepos].value) {
-        previousrle = run_container_append_first(dst, src_1->runs[rlepos]);
-        rlepos++;
-    } else {
-        previousrle = run_container_append_first(dst, src_2->runs[xrlepos]);
-        xrlepos++;
-    }
-
-    while ((xrlepos < src_2->n_runs) && (rlepos < src_1->n_runs)) {
-        rle16_t newrl;
-        if (src_1->runs[rlepos].value <= src_2->runs[xrlepos].value) {
-            newrl = src_1->runs[rlepos];
-            rlepos++;
-        } else {
-            newrl = src_2->runs[xrlepos];
-            xrlepos++;
-        }
-        run_container_append(dst, newrl, &previousrle);
-    }
-    while (xrlepos < src_2->n_runs) {
-        run_container_append(dst, src_2->runs[xrlepos], &previousrle);
-        xrlepos++;
-    }
-    while (rlepos < src_1->n_runs) {
-        run_container_append(dst, src_1->runs[rlepos], &previousrle);
-        rlepos++;
-    }
-}
-
-/* Compute the union of `src_1' and `src_2' and write the result to `src_1'
- */
-void run_container_union_inplace(run_container_t *src_1,
-                                 const run_container_t *src_2) {
-    // TODO: this could be a lot more efficient
-
-    // we start out with inexpensive checks
-    const bool if1 = run_container_is_full(src_1);
-    const bool if2 = run_container_is_full(src_2);
-    if (if1 || if2) {
-        if (if1) {
-            return;
-        }
-        if (if2) {
-            run_container_copy(src_2, src_1);
-            return;
-        }
-    }
-    // we move the data to the end of the current array
-    const int32_t maxoutput = src_1->n_runs + src_2->n_runs;
-    const int32_t neededcapacity = maxoutput + src_1->n_runs;
-    if (src_1->capacity < neededcapacity)
-        run_container_grow(src_1, neededcapacity, true);
-    memmove(src_1->runs + maxoutput, src_1->runs,
-            src_1->n_runs * sizeof(rle16_t));
-    rle16_t *inputsrc1 = src_1->runs + maxoutput;
-    const int32_t input1nruns = src_1->n_runs;
-    src_1->n_runs = 0;
-    int32_t rlepos = 0;
-    int32_t xrlepos = 0;
-
-    rle16_t previousrle;
-    if (inputsrc1[rlepos].value <= src_2->runs[xrlepos].value) {
-        previousrle = run_container_append_first(src_1, inputsrc1[rlepos]);
-        rlepos++;
-    } else {
-        previousrle = run_container_append_first(src_1, src_2->runs[xrlepos]);
-        xrlepos++;
-    }
-    while ((xrlepos < src_2->n_runs) && (rlepos < input1nruns)) {
-        rle16_t newrl;
-        if (inputsrc1[rlepos].value <= src_2->runs[xrlepos].value) {
-            newrl = inputsrc1[rlepos];
-            rlepos++;
-        } else {
-            newrl = src_2->runs[xrlepos];
-            xrlepos++;
-        }
-        run_container_append(src_1, newrl, &previousrle);
-    }
-    while (xrlepos < src_2->n_runs) {
-        run_container_append(src_1, src_2->runs[xrlepos], &previousrle);
-        xrlepos++;
-    }
-    while (rlepos < input1nruns) {
-        run_container_append(src_1, inputsrc1[rlepos], &previousrle);
-        rlepos++;
-    }
-}
-
-/* Compute the symmetric difference of `src_1' and `src_2' and write the result
- * to `dst'
- * It is assumed that `dst' is distinct from both `src_1' and `src_2'. */
-void run_container_xor(const run_container_t *src_1,
-                       const run_container_t *src_2, run_container_t *dst) {
-    // don't bother to convert xor with full range into negation
-    // since negation is implemented similarly
-
-    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
-    if (dst->capacity < neededcapacity)
-        run_container_grow(dst, neededcapacity, false);
-
-    int32_t pos1 = 0;
-    int32_t pos2 = 0;
-    dst->n_runs = 0;
-
-    while ((pos1 < src_1->n_runs) && (pos2 < src_2->n_runs)) {
-        if (src_1->runs[pos1].value <= src_2->runs[pos2].value) {
-            run_container_smart_append_exclusive(dst, src_1->runs[pos1].value,
-                                                 src_1->runs[pos1].length);
-            pos1++;
-        } else {
-            run_container_smart_append_exclusive(dst, src_2->runs[pos2].value,
-                                                 src_2->runs[pos2].length);
-            pos2++;
-        }
-    }
-    while (pos1 < src_1->n_runs) {
-        run_container_smart_append_exclusive(dst, src_1->runs[pos1].value,
-                                             src_1->runs[pos1].length);
-        pos1++;
-    }
-
-    while (pos2 < src_2->n_runs) {
-        run_container_smart_append_exclusive(dst, src_2->runs[pos2].value,
-                                             src_2->runs[pos2].length);
-        pos2++;
-    }
-}
-
-/* Compute the intersection of src_1 and src_2 and write the result to
- * dst. It is assumed that dst is distinct from both src_1 and src_2. */
-void run_container_intersection(const run_container_t *src_1,
-                                const run_container_t *src_2,
-                                run_container_t *dst) {
-    const bool if1 = run_container_is_full(src_1);
-    const bool if2 = run_container_is_full(src_2);
-    if (if1 || if2) {
-        if (if1) {
-            run_container_copy(src_2, dst);
-            return;
-        }
-        if (if2) {
-            run_container_copy(src_1, dst);
-            return;
-        }
-    }
-    // TODO: this could be a lot more efficient, could use SIMD optimizations
-    const int32_t neededcapacity = src_1->n_runs + src_2->n_runs;
-    if (dst->capacity < neededcapacity)
-        run_container_grow(dst, neededcapacity, false);
-    dst->n_runs = 0;
-    int32_t rlepos = 0;
-    int32_t xrlepos = 0;
-    int32_t start = src_1->runs[rlepos].value;
-    int32_t end = start + src_1->runs[rlepos].length + 1;
-    int32_t xstart = src_2->runs[xrlepos].value;
-    int32_t xend = xstart + src_2->runs[xrlepos].length + 1;
-    while ((rlepos < src_1->n_runs) && (xrlepos < src_2->n_runs)) {
-        if (end <= xstart) {
-            ++rlepos;
-            if (rlepos < src_1->n_runs) {
-                start = src_1->runs[rlepos].value;
-                end = start + src_1->runs[rlepos].length + 1;
-            }
-        } else if (xend <= start) {
-            ++xrlepos;
-            if (xrlepos < src_2->n_runs) {
-                xstart = src_2->runs[xrlepos].value;
-                xend = xstart + src_2->runs[xrlepos].length + 1;
-            }
-        } else {  // they overlap
-            const int32_t lateststart = start > xstart ? start : xstart;
-            int32_t earliestend;
-            if (end == xend) {  // improbable
-                earliestend = end;
-                rlepos++;
-                xrlepos++;
-                if (rlepos < src_1->n_runs) {
-                    start = src_1->runs[rlepos].value;
-                    end = start + src_1->runs[rlepos].length + 1;
-                }
-                if (xrlepos < src_2->n_runs) {
-                    xstart = src_2->runs[xrlepos].value;
-                    xend = xstart + src_2->runs[xrlepos].length + 1;
-                }
-            } else if (end < xend) {
-                earliestend = end;
-                rlepos++;
-                if (rlepos < src_1->n_runs) {
-                    start = src_1->runs[rlepos].value;
-                    end = start + src_1->runs[rlepos].length + 1;
-                }
-
-            } else {  // end > xend
-                earliestend = xend;
-                xrlepos++;
-                if (xrlepos < src_2->n_runs) {
-                    xstart = src_2->runs[xrlepos].value;
-                    xend = xstart + src_2->runs[xrlepos].length + 1;
-                }
-            }
-            dst->runs[dst->n_runs].value = lateststart;
-            dst->runs[dst->n_runs].length = (earliestend - lateststart - 1);
-            dst->n_runs++;
-        }
-    }
-}
-
-/* Compute the difference of src_1 and src_2 and write the result to
- * dst. It is assumed that dst is distinct from both src_1 and src_2. */
-void run_container_andnot(const run_container_t *src_1,
-                          const run_container_t *src_2, run_container_t *dst) {
-    // following Java implementation as of June 2016
-
-    if (dst->capacity < src_1->n_runs + src_2->n_runs)
-        run_container_grow(dst, src_1->n_runs + src_2->n_runs, false);
-
-    dst->n_runs = 0;
-
-    int rlepos1 = 0;
-    int rlepos2 = 0;
-    int32_t start = src_1->runs[rlepos1].value;
-    int32_t end = start + src_1->runs[rlepos1].length + 1;
-    int32_t start2 = src_2->runs[rlepos2].value;
-    int32_t end2 = start2 + src_2->runs[rlepos2].length + 1;
-
-    while ((rlepos1 < src_1->n_runs) && (rlepos2 < src_2->n_runs)) {
-        if (end <= start2) {
-            // output the first run
-            dst->runs[dst->n_runs++] =
-                (rle16_t){.value = (uint16_t)start,
-                          .length = (uint16_t)(end - start - 1)};
-            rlepos1++;
-            if (rlepos1 < src_1->n_runs) {
-                start = src_1->runs[rlepos1].value;
-                end = start + src_1->runs[rlepos1].length + 1;
-            }
-        } else if (end2 <= start) {
-            // exit the second run
-            rlepos2++;
-            if (rlepos2 < src_2->n_runs) {
-                start2 = src_2->runs[rlepos2].value;
-                end2 = start2 + src_2->runs[rlepos2].length + 1;
-            }
-        } else {
-            if (start < start2) {
-                dst->runs[dst->n_runs++] =
-                    (rle16_t){.value = (uint16_t)start,
-                              .length = (uint16_t)(start2 - start - 1)};
-            }
-            if (end2 < end) {
-                start = end2;
-            } else {
-                rlepos1++;
-                if (rlepos1 < src_1->n_runs) {
-                    start = src_1->runs[rlepos1].value;
-                    end = start + src_1->runs[rlepos1].length + 1;
-                }
-            }
-        }
-    }
-    if (rlepos1 < src_1->n_runs) {
-        dst->runs[dst->n_runs++] = (rle16_t){
-            .value = (uint16_t)start, .length = (uint16_t)(end - start - 1)};
-        rlepos1++;
-        if (rlepos1 < src_1->n_runs) {
-            memcpy(dst->runs + dst->n_runs, src_1->runs + rlepos1,
-                   sizeof(rle16_t) * (src_1->n_runs - rlepos1));
-            dst->n_runs += src_1->n_runs - rlepos1;
-        }
-    }
-}
-
-int run_container_to_uint32_array(uint32_t *out, const run_container_t *cont,
-                                  uint32_t base) {
-    int outpos = 0;
-    for (int i = 0; i < cont->n_runs; ++i) {
-        uint32_t run_start = base + cont->runs[i].value;
-        uint16_t le = cont->runs[i].length;
-        for (int j = 0; j <= le; ++j) out[outpos++] = run_start + j;
-    }
-    return outpos;
-}
-
-/*
- * Print this container using printf (useful for debugging).
- */
-void run_container_printf(const run_container_t *cont) {
-    for (int i = 0; i < cont->n_runs; ++i) {
-        uint16_t run_start = cont->runs[i].value;
-        uint16_t le = cont->runs[i].length;
-        printf("[%d,%d]", run_start, run_start + le);
-    }
-}
-
-/*
- * Print this container using printf as a comma-separated list of 32-bit
- * integers starting at base.
- */
-void run_container_printf_as_uint32_array(const run_container_t *cont,
-                                          uint32_t base) {
-    if (cont->n_runs == 0) return;
-    {
-        uint32_t run_start = base + cont->runs[0].value;
-        uint16_t le = cont->runs[0].length;
-        printf("%d", run_start);
-        for (uint32_t j = 1; j <= le; ++j) printf(",%d", run_start + j);
-    }
-    for (int32_t i = 1; i < cont->n_runs; ++i) {
-        uint32_t run_start = base + cont->runs[i].value;
-        uint16_t le = cont->runs[i].length;
-        for (uint32_t j = 0; j <= le; ++j) printf(",%d", run_start + j);
-    }
-}
-
-int32_t run_container_serialize(run_container_t *container, char *buf) {
-    int32_t l, off;
-
-    memcpy(buf, &container->n_runs, off = sizeof(container->n_runs));
-    memcpy(&buf[off], &container->capacity, sizeof(container->capacity));
-    off += sizeof(container->capacity);
-
-    l = sizeof(rle16_t) * container->n_runs;
-    memcpy(&buf[off], container->runs, l);
-    return (off + l);
-}
-
-int32_t run_container_write(const run_container_t *container, char *buf) {
-    if (IS_BIG_ENDIAN) {
-        // forcing little endian (could be faster)
-        buf[0] = (uint8_t)(container->n_runs);
-        buf[1] = (uint8_t)(container->n_runs >> 8);
-        for (int32_t i = 0; i < container->n_runs; i++) {
-            rle16_t val = container->runs[i];
-            buf[2 + 4 * i] = (uint8_t)(val.value);
-            buf[2 + 4 * i + 1] = (uint8_t)(val.value >> 8);
-            buf[2 + 4 * i + 2] = (uint8_t)(val.length);
-            buf[2 + 4 * i + 3] = (uint8_t)(val.length >> 8);
-        }
-    } else {
-        memcpy(buf, &container->n_runs, sizeof(uint16_t));
-        memcpy(buf + sizeof(uint16_t), container->runs,
-               container->n_runs * sizeof(rle16_t));
-    }
-    return run_container_size_in_bytes(container);
-}
-
-int32_t run_container_read(int32_t cardinality, run_container_t *container,
-                           const char *buf) {
-    (void)cardinality;
-    assert(!IS_BIG_ENDIAN);  // TODO: Implement
-    memcpy(&container->n_runs, buf, sizeof(uint16_t));
-    if (container->n_runs > container->capacity)
-        run_container_grow(container, container->n_runs, false);
-    memcpy(container->runs, buf + sizeof(uint16_t),
-           container->n_runs * sizeof(rle16_t));
-    return run_container_size_in_bytes(container);
-}
-
-uint32_t run_container_serialization_len(run_container_t *container) {
-    return (sizeof(container->n_runs) + sizeof(container->capacity) +
-            sizeof(rle16_t) * container->n_runs);
-}
-
-void *run_container_deserialize(const char *buf, size_t buf_len) {
-    run_container_t *ptr;
-
-    if (buf_len < 8 /* n_runs + capacity */)
-        return (NULL);
-    else
-        buf_len -= 8;
-
-    if ((ptr = (run_container_t *)malloc(sizeof(run_container_t))) != NULL) {
-        size_t len;
-        int32_t off;
-
-        memcpy(&ptr->n_runs, buf, off = 4);
-        memcpy(&ptr->capacity, &buf[off], 4);
-        off += 4;
-
-        len = sizeof(rle16_t) * ptr->n_runs;
-
-        if (len != buf_len) {
-            free(ptr);
-            return (NULL);
-        }
-
-        if ((ptr->runs = (rle16_t *)malloc(len)) == NULL) {
-            free(ptr);
-            return (NULL);
-        }
-
-        memcpy(ptr->runs, &buf[off], len);
-
-        /* Check if returned values are monotonically increasing */
-        for (int32_t i = 0, j = 0; i < ptr->n_runs; i++) {
-            if (ptr->runs[i].value < j) {
-                free(ptr->runs);
-                free(ptr);
-                return (NULL);
-            } else
-                j = ptr->runs[i].value;
-        }
-    }
-
-    return (ptr);
-}
-
-bool run_container_iterate(const run_container_t *cont, uint32_t base,
-                           roaring_iterator iterator, void *ptr) {
-    for (int i = 0; i < cont->n_runs; ++i) {
-        uint32_t run_start = base + cont->runs[i].value;
-        uint16_t le = cont->runs[i].length;
-
-        for (int j = 0; j <= le; ++j)
-            if (!iterator(run_start + j, ptr)) return false;
-    }
-    return true;
-}
-
-bool run_container_equals(run_container_t *container1,
-                          run_container_t *container2) {
-    if (container1->n_runs != container2->n_runs) {
-        return false;
-    }
-    for (int32_t i = 0; i < container1->n_runs; ++i) {
-        if ((container1->runs[i].value != container2->runs[i].value) ||
-            (container1->runs[i].length != container2->runs[i].length))
-            return false;
-    }
-    return true;
-}
-
-// TODO: write smart_append_exclusive version to match the overloaded 1 param
-// Java version (or  is it even used?)
-
-// follows the Java implementation closely
-// length is the rle-value.  Ie, run [10,12) uses a length value 1.
-void run_container_smart_append_exclusive(run_container_t *src,
-                                          const uint16_t start,
-                                          const uint16_t length) {
-    int old_end;
-    rle16_t *last_run = src->n_runs ? src->runs + (src->n_runs - 1) : NULL;
-    rle16_t *appended_last_run = src->runs + src->n_runs;
-
-    if (!src->n_runs ||
-        (start > (old_end = last_run->value + last_run->length + 1))) {
-        *appended_last_run = (rle16_t){.value = start, .length = length};
-        src->n_runs++;
-        return;
-    }
-    if (old_end == start) {
-        // we merge
-        last_run->length += (length + 1);
-        return;
-    }
-    int new_end = start + length + 1;
-
-    if (start == last_run->value) {
-        // wipe out previous
-        if (new_end < old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)new_end,
-                                  .length = (uint16_t)(old_end - new_end - 1)};
-            return;
-        } else if (new_end > old_end) {
-            *last_run = (rle16_t){.value = (uint16_t)old_end,
-                                  .length = (uint16_t)(new_end - old_end - 1)};
-            return;
-        } else {
-            src->n_runs--;
-            return;
-        }
-    }
-    last_run->length = start - last_run->value - 1;
-    if (new_end < old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)new_end,
-                      .length = (uint16_t)(old_end - new_end - 1)};
-        src->n_runs++;
-    } else if (new_end > old_end) {
-        *appended_last_run =
-            (rle16_t){.value = (uint16_t)old_end,
-                      .length = (uint16_t)(new_end - old_end - 1)};
-        src->n_runs++;
-    }
-}
-
-bool run_container_select(const run_container_t *container,
-                          uint32_t *start_rank, uint32_t rank,
-                          uint32_t *element) {
-    for (int i = 0; i < container->n_runs; i++) {
-        uint16_t length = container->runs[i].length;
-        if (rank <= *start_rank + length) {
-            uint16_t value = container->runs[i].value;
-            *element = value + rank - (*start_rank);
-            return true;
-        } else
-            *start_rank += length + 1;
-    }
-    return false;
-}
-/* end file /Users/saulius/repos/CRoaring/src/containers/run.c */
-/* begin file /Users/saulius/repos/CRoaring/src/roaring.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/roaring.c"
+/* end file /home/dlemire/CVS/github/CRoaring/src/bitset_util.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/roaring.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/roaring.c"
 #include <assert.h>
 #include <stdarg.h>
 #include <stdint.h>
@@ -6054,14 +6305,51 @@ bool run_container_select(const run_container_t *container,
 
 extern inline bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val);
 
+
+// this is like roaring_bitmap_add, but it populates pointer arguments in such a way
+// that we can recover the container touched, which, in turn can be used to
+// accelerate some functions (when you repeatedly need to add to the same container)
+static inline void * containerptr_roaring_bitmap_add(roaring_bitmap_t *r, uint32_t val, uint8_t * typecode, int * index) {
+    uint16_t hb = val >> 16;
+    const int i = ra_get_index(& r->high_low_container, hb);
+    if (i >= 0) {
+        ra_unshare_container_at_index(& r->high_low_container, i);
+        void * container =
+            ra_get_container_at_index(& r->high_low_container, i, typecode);
+        uint8_t newtypecode = *typecode;
+        void *container2 =
+            container_add(container, val & 0xFFFF, *typecode, &newtypecode);
+        *index = i;
+        if (container2 != container) {
+            container_free(container, *typecode);
+            ra_set_container_at_index(& r->high_low_container, i, container2,
+                                      newtypecode);
+            *typecode = newtypecode;
+            return container2;
+        } else {
+        	return container;
+        }
+    } else {
+        array_container_t *newac = array_container_create();
+        void * container = container_add(newac, val & 0xFFFF,
+                                        ARRAY_CONTAINER_TYPE_CODE, typecode);
+        // we could just assume that it stays an array container
+        ra_insert_new_key_value_at(& r->high_low_container, -i - 1, hb, container,
+                                   *typecode);
+        * index =  -i - 1;
+        return container;
+    }
+}
+
+
 roaring_bitmap_t *roaring_bitmap_create() {
     roaring_bitmap_t *ans =
         (roaring_bitmap_t *)malloc(sizeof(roaring_bitmap_t));
     if (!ans) {
         return NULL;
     }
-    ans->high_low_container = ra_create();
-    if (!ans->high_low_container) {
+    bool is_ok = ra_init(& ans->high_low_container);
+    if (!is_ok) {
         free(ans);
         return NULL;
     }
@@ -6075,8 +6363,8 @@ roaring_bitmap_t *roaring_bitmap_create_with_capacity(uint32_t cap) {
     if (!ans) {
         return NULL;
     }
-    ans->high_low_container = ra_create_with_capacity(cap);
-    if (!ans->high_low_container) {
+    bool is_ok = ra_init_with_capacity(& ans->high_low_container, cap);
+    if (!is_ok) {
         free(ans);
         return NULL;
     }
@@ -6085,16 +6373,45 @@ roaring_bitmap_t *roaring_bitmap_create_with_capacity(uint32_t cap) {
 }
 
 roaring_bitmap_t *roaring_bitmap_of_ptr(size_t n_args, const uint32_t *vals) {
-    // todo: could be greatly optimized
     roaring_bitmap_t *answer = roaring_bitmap_create();
-    for (size_t i = 0; i < n_args; i++) {
-        roaring_bitmap_add(answer, vals[i]);
+    void * container = NULL; // hold value of last container touched
+    uint8_t typecode = 0; // typecode of last container touched
+    uint32_t prev = 0; // previous valued inserted
+    size_t i = 0; // index of value
+    int containerindex = 0;
+    if(n_args > 0) {
+        uint32_t val;
+        memcpy(&val, vals + i, sizeof(val));
+    	container = containerptr_roaring_bitmap_add(answer, val, &typecode, &containerindex);
+    	prev = val;
+    	i++;
+    }
+    for (; i < n_args; i++) {
+        uint32_t val;
+        memcpy(&val, vals + i, sizeof(val));
+    	if(((prev ^ val) >> 16) == 0) { // no need to seek the container, it is at hand
+    		// because we already have the container at hand, we can do the insertion
+    		// automatically, bypassing the roaring_bitmap_add call
+            uint8_t newtypecode = typecode;
+            void *container2 =
+                container_add(container, val & 0xFFFF, typecode, &newtypecode);
+            if (container2 != container) { // rare instance when we need to change the container type
+                container_free(container, typecode);
+                ra_set_container_at_index(& answer->high_low_container, containerindex, container2,
+                                          newtypecode);
+                typecode = newtypecode;
+                container =  container2;
+            }
+    	} else {
+        	container = containerptr_roaring_bitmap_add(answer, val, &typecode, &containerindex);
+    	}
+    	prev  = val;
     }
     return answer;
 }
 
 roaring_bitmap_t *roaring_bitmap_of(size_t n_args, ...) {
-    // todo: could be greatly optimized
+    // todo: could be greatly optimized but we do not expect this call to ever include long lists
     roaring_bitmap_t *answer = roaring_bitmap_create();
     va_list ap;
     va_start(ap, n_args);
@@ -6129,7 +6446,7 @@ roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max,
         uint8_t type;
         void *container = container_from_range(&type, container_min,
                                                container_max, (uint16_t)step);
-        ra_append(answer->high_low_container, key, container, type);
+        ra_append(& answer->high_low_container, key, container, type);
         uint32_t gap = container_max - container_min + step - 1;
         min_tmp += gap - (gap % step);
     } while (min_tmp < max);
@@ -6139,33 +6456,29 @@ roaring_bitmap_t *roaring_bitmap_from_range(uint32_t min, uint32_t max,
 
 void roaring_bitmap_printf(const roaring_bitmap_t *ra) {
     printf("{");
-    for (int i = 0; i < ra->high_low_container->size; ++i) {
-        container_printf_as_uint32_array(
-            ra->high_low_container->containers[i],
-            ra->high_low_container->typecodes[i],
-            ((uint32_t)ra->high_low_container->keys[i]) << 16);
-        if (i + 1 < ra->high_low_container->size) printf(",");
+    for (int i = 0; i < ra->high_low_container.size; ++i) {
+        container_printf_as_uint32_array(ra->high_low_container.containers[i],  ra->high_low_container.typecodes[i],
+            ((uint32_t)ra->high_low_container.keys[i]) << 16);
+        if (i + 1 < ra->high_low_container.size) printf(",");
     }
     printf("}");
 }
 
 void roaring_bitmap_printf_describe(const roaring_bitmap_t *ra) {
     printf("{");
-    for (int i = 0; i < ra->high_low_container->size; ++i) {
-        printf("%d: %s (%d)", ra->high_low_container->keys[i],
-               get_full_container_name(ra->high_low_container->containers[i],
-                                       ra->high_low_container->typecodes[i]),
-               container_get_cardinality(ra->high_low_container->containers[i],
-                                         ra->high_low_container->typecodes[i]));
-        if (ra->high_low_container->typecodes[i] ==
+    for (int i = 0; i < ra->high_low_container.size; ++i) {
+        printf("%d: %s (%d)",  ra->high_low_container.keys[i],
+               get_full_container_name(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]),
+               container_get_cardinality(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]));
+        if (ra->high_low_container.typecodes[i] ==
             SHARED_CONTAINER_TYPE_CODE) {
             printf(
                 "(shared count = %d )",
-                ((shared_container_t *)(ra->high_low_container->containers[i]))
+                ((shared_container_t *)(ra->high_low_container.containers[i]))
                     ->counter);
         }
 
-        if (i + 1 < ra->high_low_container->size) printf(", ");
+        if (i + 1 < ra->high_low_container.size) printf(", ");
     }
     printf("}");
 }
@@ -6191,7 +6504,7 @@ static bool min_max_sum_fnc(uint32_t value, void *param) {
 void roaring_bitmap_statistics(const roaring_bitmap_t *ra,
                                roaring_statistics_t *stat) {
     memset(stat, 0, sizeof(*stat));
-    stat->n_containers = ra->high_low_container->size;
+    stat->n_containers = ra->high_low_container.size;
     stat->cardinality = roaring_bitmap_get_cardinality(ra);
     min_max_sum_t mms;
     mms.min = UINT32_C(0xFFFFFFFF);
@@ -6202,16 +6515,13 @@ void roaring_bitmap_statistics(const roaring_bitmap_t *ra,
     stat->max_value = mms.max;
     stat->sum_value = mms.sum;
 
-    for (int i = 0; i < ra->high_low_container->size; ++i) {
+    for (int i = 0; i < ra->high_low_container.size; ++i) {
         uint8_t truetype =
-            get_container_type(ra->high_low_container->containers[i],
-                               ra->high_low_container->typecodes[i]);
+            get_container_type(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]);
         uint32_t card =
-            container_get_cardinality(ra->high_low_container->containers[i],
-                                      ra->high_low_container->typecodes[i]);
+            container_get_cardinality(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]);
         uint32_t sbytes =
-            container_size_in_bytes(ra->high_low_container->containers[i],
-                                    ra->high_low_container->typecodes[i]);
+            container_size_in_bytes(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]);
         switch (truetype) {
             case BITSET_CONTAINER_TYPE_CODE:
                 stat->n_bitset_containers++;
@@ -6241,8 +6551,8 @@ roaring_bitmap_t *roaring_bitmap_copy(const roaring_bitmap_t *r) {
     if (!ans) {
         return NULL;
     }
-    ans->high_low_container = ra_copy(r->high_low_container, r->copy_on_write);
-    if (!ans->high_low_container) {
+    bool is_ok = ra_copy(& r->high_low_container,& ans->high_low_container, r->copy_on_write);
+    if (!is_ok) {
         free(ans);
         return NULL;
     }
@@ -6250,35 +6560,30 @@ roaring_bitmap_t *roaring_bitmap_copy(const roaring_bitmap_t *r) {
     return ans;
 }
 
-static void roaring_bitmap_overwrite(roaring_bitmap_t *dest,
+static bool roaring_bitmap_overwrite(roaring_bitmap_t *dest,
                                      const roaring_bitmap_t *src) {
-    ra_free(dest->high_low_container);
-    dest->high_low_container =
-        ra_copy(src->high_low_container, src->copy_on_write);
-    // TODO any better error handling
-    assert(dest->high_low_container);
+    return ra_overwrite(& src->high_low_container, & dest->high_low_container, src->copy_on_write);
 }
 
 void roaring_bitmap_free(roaring_bitmap_t *r) {
-    ra_free(r->high_low_container);
-    r->high_low_container = NULL;  // paranoid
+    ra_clear(& r->high_low_container);
     free(r);
 }
 
 void roaring_bitmap_add(roaring_bitmap_t *r, uint32_t val) {
     const uint16_t hb = val >> 16;
-    const int i = ra_get_index(r->high_low_container, hb);
+    const int i = ra_get_index(& r->high_low_container, hb);
     uint8_t typecode;
     if (i >= 0) {
-        ra_unshare_container_at_index(r->high_low_container, i);
+        ra_unshare_container_at_index(& r->high_low_container, i);
         void *container =
-            ra_get_container_at_index(r->high_low_container, i, &typecode);
+            ra_get_container_at_index(& r->high_low_container, i, &typecode);
         uint8_t newtypecode = typecode;
         void *container2 =
             container_add(container, val & 0xFFFF, typecode, &newtypecode);
         if (container2 != container) {
             container_free(container, typecode);
-            ra_set_container_at_index(r->high_low_container, i, container2,
+            ra_set_container_at_index(& r->high_low_container, i, container2,
                                       newtypecode);
         }
     } else {
@@ -6286,32 +6591,32 @@ void roaring_bitmap_add(roaring_bitmap_t *r, uint32_t val) {
         void *container = container_add(newac, val & 0xFFFF,
                                         ARRAY_CONTAINER_TYPE_CODE, &typecode);
         // we could just assume that it stays an array container
-        ra_insert_new_key_value_at(r->high_low_container, -i - 1, hb, container,
+        ra_insert_new_key_value_at(& r->high_low_container, -i - 1, hb, container,
                                    typecode);
     }
 }
 
 void roaring_bitmap_remove(roaring_bitmap_t *r, uint32_t val) {
     const uint16_t hb = val >> 16;
-    const int i = ra_get_index(r->high_low_container, hb);
+    const int i = ra_get_index(& r->high_low_container, hb);
     uint8_t typecode;
     if (i >= 0) {
-        ra_unshare_container_at_index(r->high_low_container, i);
+        ra_unshare_container_at_index(& r->high_low_container, i);
         void *container =
-            ra_get_container_at_index(r->high_low_container, i, &typecode);
+            ra_get_container_at_index(& r->high_low_container, i, &typecode);
         uint8_t newtypecode = typecode;
         void *container2 =
             container_remove(container, val & 0xFFFF, typecode, &newtypecode);
         if (container2 != container) {
             container_free(container, typecode);
-            ra_set_container_at_index(r->high_low_container, i, container2,
+            ra_set_container_at_index(& r->high_low_container, i, container2,
                                       newtypecode);
         }
         if (container_get_cardinality(container2, newtypecode) != 0) {
-            ra_set_container_at_index(r->high_low_container, i, container2,
+            ra_set_container_at_index(& r->high_low_container, i, container2,
                                       newtypecode);
         } else {
-            ra_remove_at_index_and_free(r->high_low_container, i);
+            ra_remove_at_index_and_free(& r->high_low_container, i);
         }
     }
 }
@@ -6322,8 +6627,8 @@ extern bool roaring_bitmap_contains(const roaring_bitmap_t *r, uint32_t val);
 roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1,
                                      const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     uint32_t neededcap = length1 > length2 ? length2 : length1;
     roaring_bitmap_t *answer = roaring_bitmap_create_with_capacity(neededcap);
     answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -6331,19 +6636,19 @@ roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1,
     int pos1 = 0, pos2 = 0;
 
     while (pos1 < length1 && pos2 < length2) {
-        const uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-        const uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+        const uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+        const uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         if (s1 == s2) {
             uint8_t container_type_1, container_type_2;
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c = container_and(c1, container_type_1, c2, container_type_2,
                                     &container_result_type);
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_append(answer->high_low_container, s1, c,
+                ra_append(& answer->high_low_container, s1, c,
                           container_result_type);
             } else {
                 container_free(
@@ -6352,9 +6657,9 @@ roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1,
             ++pos1;
             ++pos2;
         } else if (s1 < s2) {  // s1 < s2
-            pos1 = ra_advance_until(x1->high_low_container, s2, pos1);
+            pos1 = ra_advance_until(& x1->high_low_container, s2, pos1);
         } else {  // s1 > s2
-            pos2 = ra_advance_until(x2->high_low_container, s1, pos2);
+            pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
         }
     }
     return answer;
@@ -6402,22 +6707,23 @@ roaring_bitmap_t *roaring_bitmap_xor_many(size_t number,
 // inplace and (modifies its first argument).
 void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
                                 const roaring_bitmap_t *x2) {
+	if( x1 == x2 ) return;
     int pos1 = 0, pos2 = 0, intersection_size = 0;
-    const int length1 = ra_get_size(x1->high_low_container);
-    const int length2 = ra_get_size(x2->high_low_container);
+    const int length1 = ra_get_size(& x1->high_low_container);
+    const int length2 = ra_get_size(& x2->high_low_container);
 
     // any skipped-over or newly emptied containers in x1
     // have to be freed.
     while (pos1 < length1 && pos2 < length2) {
-        const uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-        const uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+        const uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+        const uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         if (s1 == s2) {
             uint8_t typecode1, typecode2, typecode_result;
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &typecode1);
             c1 = get_writable_copy_if_shared(c1, &typecode1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &typecode2);
             void *c =
                 container_iand(c1, typecode1, c2, typecode2, &typecode_result);
@@ -6426,7 +6732,7 @@ void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
                 container_free(c1, typecode1);
             }
             if (container_nonzero_cardinality(c, typecode_result)) {
-                ra_replace_key_and_container_at_index(x1->high_low_container,
+                ra_replace_key_and_container_at_index(& x1->high_low_container,
                                                       intersection_size, s1, c,
                                                       typecode_result);
                 intersection_size++;
@@ -6436,29 +6742,28 @@ void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
             ++pos1;
             ++pos2;
         } else if (s1 < s2) {
-            pos1 = ra_advance_until_freeing(x1->high_low_container, s2, pos1);
+            pos1 = ra_advance_until_freeing(& x1->high_low_container, s2, pos1);
         } else {  // s1 > s2
-            pos2 = ra_advance_until(x2->high_low_container, s1, pos2);
+            pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
         }
     }
 
     // if we ended early because x2 ran out, then all remaining in x1 should be
     // freed
     while (pos1 < length1) {
-        container_free(x1->high_low_container->containers[pos1],
-                       x1->high_low_container->typecodes[pos1]);
+        container_free(x1->high_low_container.containers[pos1], x1->high_low_container.typecodes[pos1]);
         ++pos1;
     }
 
     // all containers after this have either been copied or freed
-    ra_downsize(x1->high_low_container, intersection_size);
+    ra_downsize(& x1->high_low_container, intersection_size);
 }
 
 roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1,
                                     const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     roaring_bitmap_t *answer =
         roaring_bitmap_create_with_capacity(length1 + length2);
     answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -6470,63 +6775,63 @@ roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c = container_or(c1, container_type_1, c2, container_type_2,
                                    &container_result_type);
             // since we assume that the initial containers are non-empty, the
             // result here
             // can only be non-empty
-            ra_append(answer->high_low_container, s1, c, container_result_type);
+            ra_append(& answer->high_low_container, s1, c, container_result_type);
             ++pos1;
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             // c1 = container_clone(c1, container_type_1);
             c1 =
                 get_copy_of_container(c1, &container_type_1, x1->copy_on_write);
             if (x1->copy_on_write) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c1,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c1,
                                           container_type_1);
             }
-            ra_append(answer->high_low_container, s1, c1, container_type_1);
+            ra_append(& answer->high_low_container, s1, c1, container_type_1);
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             // c2 = container_clone(c2, container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_append(answer->high_low_container, s2, c2, container_type_2);
+            ra_append(& answer->high_low_container, s2, c2, container_type_2);
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(answer->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     } else if (pos2 == length2) {
-        ra_append_copy_range(answer->high_low_container, x1->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x1->high_low_container,
                              pos1, length1, x1->copy_on_write);
     }
     return answer;
@@ -6536,8 +6841,8 @@ roaring_bitmap_t *roaring_bitmap_or(const roaring_bitmap_t *x1,
 void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
                                const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    int length1 = x1->high_low_container->size;
-    const int length2 = x2->high_low_container->size;
+    int length1 = x1->high_low_container.size;
+    const int length2 = x2->high_low_container.size;
 
     if (0 == length2) return;
 
@@ -6547,15 +6852,15 @@ void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 = get_writable_copy_if_shared(c1, &container_type_1);
 
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c = container_ior(c1, container_type_1, c2, container_type_2,
                                     &container_result_type);
@@ -6564,42 +6869,42 @@ void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
                 container_free(c1, container_type_1);
             }
 
-            ra_set_container_at_index(x1->high_low_container, pos1, c,
+            ra_set_container_at_index(& x1->high_low_container, pos1, c,
                                       container_result_type);
             ++pos1;
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
 
             // void *c2_clone = container_clone(c2, container_type_2);
-            ra_insert_new_key_value_at(x1->high_low_container, pos1, s2, c2,
+            ra_insert_new_key_value_at(& x1->high_low_container, pos1, s2, c2,
                                        container_type_2);
             pos1++;
             length1++;
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(x1->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& x1->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     }
 }
@@ -6607,8 +6912,8 @@ void roaring_bitmap_or_inplace(roaring_bitmap_t *x1,
 roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1,
                                      const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     roaring_bitmap_t *answer =
         roaring_bitmap_create_with_capacity(length1 + length2);
     answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -6620,19 +6925,19 @@ roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c = container_xor(c1, container_type_1, c2, container_type_2,
                                     &container_result_type);
 
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_append(answer->high_low_container, s1, c,
+                ra_append(& answer->high_low_container, s1, c,
                           container_result_type);
             } else {
                 container_free(c, container_result_type);
@@ -6641,43 +6946,43 @@ roaring_bitmap_t *roaring_bitmap_xor(const roaring_bitmap_t *x1,
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 =
                 get_copy_of_container(c1, &container_type_1, x1->copy_on_write);
             if (x1->copy_on_write) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c1,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c1,
                                           container_type_1);
             }
-            ra_append(answer->high_low_container, s1, c1, container_type_1);
+            ra_append(& answer->high_low_container, s1, c1, container_type_1);
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_append(answer->high_low_container, s2, c2, container_type_2);
+            ra_append(& answer->high_low_container, s2, c2, container_type_2);
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(answer->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     } else if (pos2 == length2) {
-        ra_append_copy_range(answer->high_low_container, x1->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x1->high_low_container,
                              pos1, length1, x1->copy_on_write);
     }
     return answer;
@@ -6689,8 +6994,8 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
                                 const roaring_bitmap_t *x2) {
     assert(x1 != x2);
     uint8_t container_result_type = 0;
-    int length1 = x1->high_low_container->size;
-    const int length2 = x2->high_low_container->size;
+    int length1 = x1->high_low_container.size;
+    const int length2 = x2->high_low_container.size;
 
     if (0 == length2) return;
 
@@ -6704,61 +7009,61 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
 
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 = get_writable_copy_if_shared(c1, &container_type_1);
 
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c = container_ixor(c1, container_type_1, c2, container_type_2,
                                      &container_result_type);
 
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c,
                                           container_result_type);
                 ++pos1;
             } else {
                 container_free(c, container_result_type);
-                ra_remove_at_index(x1->high_low_container, pos1);
+                ra_remove_at_index(& x1->high_low_container, pos1);
                 --length1;
             }
 
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
 
-            ra_insert_new_key_value_at(x1->high_low_container, pos1, s2, c2,
+            ra_insert_new_key_value_at(& x1->high_low_container, pos1, s2, c2,
                                        container_type_2);
             pos1++;
             length1++;
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(x1->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& x1->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     }
 }
@@ -6766,8 +7071,8 @@ void roaring_bitmap_xor_inplace(roaring_bitmap_t *x1,
 roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *x1,
                                         const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     if (0 == length1) {
         roaring_bitmap_t *empty_bitmap = roaring_bitmap_create();
         empty_bitmap->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -6784,20 +7089,20 @@ roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *x1,
     uint16_t s1 = 0;
     uint16_t s2 = 0;
     while (true) {
-        s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-        s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+        s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+        s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c =
                 container_andnot(c1, container_type_1, c2, container_type_2,
                                  &container_result_type);
 
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_append(answer->high_low_container, s1, c,
+                ra_append(& answer->high_low_container, s1, c,
                           container_result_type);
             } else {
                 container_free(c, container_result_type);
@@ -6808,21 +7113,20 @@ roaring_bitmap_t *roaring_bitmap_andnot(const roaring_bitmap_t *x1,
             if (pos2 == length2) break;
         } else if (s1 < s2) {  // s1 < s2
             const int next_pos1 =
-                ra_advance_until(x1->high_low_container, s2, pos1);
-            ra_append_copy_range(answer->high_low_container,
-                                 x1->high_low_container, pos1, next_pos1,
+                ra_advance_until(& x1->high_low_container, s2, pos1);
+            ra_append_copy_range(& answer->high_low_container, & x1->high_low_container, pos1, next_pos1,
                                  x1->copy_on_write);
             // TODO : perhaps some of the copy_on_write should be based on
             // answer rather than x1 (more stringent?).  Many similar cases
             pos1 = next_pos1;
             if (pos1 == length1) break;
         } else {  // s1 > s2
-            pos2 = ra_advance_until(x2->high_low_container, s1, pos2);
+            pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
             if (pos2 == length2) break;
         }
     }
     if (pos2 == length2) {
-        ra_append_copy_range(answer->high_low_container, x1->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x1->high_low_container,
                              pos1, length1, x1->copy_on_write);
     }
     return answer;
@@ -6835,8 +7139,8 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
     assert(x1 != x2);
 
     uint8_t container_result_type = 0;
-    int length1 = x1->high_low_container->size;
-    const int length2 = x2->high_low_container->size;
+    int length1 = x1->high_low_container.size;
+    const int length2 = x2->high_low_container.size;
     int intersection_size = 0;
 
     if (0 == length2) return;
@@ -6850,22 +7154,22 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
 
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 = get_writable_copy_if_shared(c1, &container_type_1);
 
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c =
                 container_iandnot(c1, container_type_1, c2, container_type_2,
                                   &container_result_type);
 
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_replace_key_and_container_at_index(x1->high_low_container,
+                ra_replace_key_and_container_at_index(& x1->high_low_container,
                                                       intersection_size++, s1,
                                                       c, container_result_type);
             } else {
@@ -6876,27 +7180,27 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
             if (pos1 != intersection_size) {
-                void *c1 = ra_get_container_at_index(x1->high_low_container,
+                void *c1 = ra_get_container_at_index(& x1->high_low_container,
                                                      pos1, &container_type_1);
 
-                ra_replace_key_and_container_at_index(x1->high_low_container,
+                ra_replace_key_and_container_at_index(& x1->high_low_container,
                                                       intersection_size, s1, c1,
                                                       container_type_1);
             }
             intersection_size++;
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            pos2 = ra_advance_until(x2->high_low_container, s1, pos2);
+            pos2 = ra_advance_until(& x2->high_low_container, s1, pos2);
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
 
@@ -6909,37 +7213,28 @@ void roaring_bitmap_andnot_inplace(roaring_bitmap_t *x1,
         // intersection_size and pos1.
         if (pos1 > intersection_size) {
             // left slide of remaining items
-            ra_copy_range(x1->high_low_container, pos1, length1,
+            ra_copy_range(& x1->high_low_container, pos1, length1,
                           intersection_size);
         }
         // else current placement is fine
         intersection_size += (length1 - pos1);
     }
-    ra_downsize(x1->high_low_container, intersection_size);
+    ra_downsize(& x1->high_low_container, intersection_size);
 }
 
 uint64_t roaring_bitmap_get_cardinality(const roaring_bitmap_t *ra) {
     uint64_t card = 0;
-    for (int i = 0; i < ra->high_low_container->size; ++i)
-        card += container_get_cardinality(ra->high_low_container->containers[i],
-                                          ra->high_low_container->typecodes[i]);
+    for (int i = 0; i < ra->high_low_container.size; ++i)
+        card += container_get_cardinality(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i]);
     return card;
 }
 
 bool roaring_bitmap_is_empty(const roaring_bitmap_t *ra) {
-    return ra->high_low_container->size == 0;
+    return ra->high_low_container.size == 0;
 }
 
 void roaring_bitmap_to_uint32_array(const roaring_bitmap_t *ra, uint32_t *ans) {
-    uint32_t ctr = 0;
-
-    for (int i = 0; i < ra->high_low_container->size; ++i) {
-        int num_added = container_to_uint32_array(
-            ans + ctr, ra->high_low_container->containers[i],
-            ra->high_low_container->typecodes[i],
-            ((uint32_t)ra->high_low_container->keys[i]) << 16);
-        ctr += num_added;
-    }
+    ra_to_uint32_array(& ra->high_low_container, ans);
 }
 
 /** convert array and bitmap containers to run containers when it is more
@@ -6949,15 +7244,14 @@ void roaring_bitmap_to_uint32_array(const roaring_bitmap_t *ra, uint32_t *ans) {
 */
 bool roaring_bitmap_run_optimize(roaring_bitmap_t *r) {
     bool answer = false;
-    for (int i = 0; i < r->high_low_container->size; i++) {
+    for (int i = 0; i < r->high_low_container.size; i++) {
         uint8_t typecode_original, typecode_after;
-        ra_unshare_container_at_index(
-            r->high_low_container, i);  // TODO: this introduces extra cloning!
-        void *c = ra_get_container_at_index(r->high_low_container, i,
+        ra_unshare_container_at_index(& r->high_low_container, i);  // TODO: this introduces extra cloning!
+        void *c = ra_get_container_at_index(& r->high_low_container, i,
                                             &typecode_original);
         void *c1 = convert_run_optimize(c, typecode_original, &typecode_after);
         if (typecode_after == RUN_CONTAINER_TYPE_CODE) answer = true;
-        ra_set_container_at_index(r->high_low_container, i, c1, typecode_after);
+        ra_set_container_at_index(& r->high_low_container, i, c1, typecode_after);
     }
     return answer;
 }
@@ -6968,9 +7262,9 @@ bool roaring_bitmap_run_optimize(roaring_bitmap_t *r) {
  */
 bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r) {
     bool answer = false;
-    for (int i = 0; i < r->high_low_container->size; i++) {
+    for (int i = 0; i < r->high_low_container.size; i++) {
         uint8_t typecode_original, typecode_after;
-        void *c = ra_get_container_at_index(r->high_low_container, i,
+        void *c = ra_get_container_at_index(& r->high_low_container, i,
                                             &typecode_original);
         if (get_container_type(c, typecode_original) ==
             RUN_CONTAINER_TYPE_CODE) {
@@ -6982,14 +7276,14 @@ bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r) {
                 void *c1 = convert_to_bitset_or_array_container(
                     truec, card, &typecode_after);
                 shared_container_free((shared_container_t *)c);
-                ra_set_container_at_index(r->high_low_container, i, c1,
+                ra_set_container_at_index(& r->high_low_container, i, c1,
                                           typecode_after);
 
             } else {
                 int32_t card = run_container_cardinality((run_container_t *)c);
                 void *c1 = convert_to_bitset_or_array_container(
                     (run_container_t *)c, card, &typecode_after);
-                ra_set_container_at_index(r->high_low_container, i, c1,
+                ra_set_container_at_index(& r->high_low_container, i, c1,
                                           typecode_after);
             }
         }
@@ -6997,33 +7291,31 @@ bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r) {
     return answer;
 }
 
-char *roaring_bitmap_serialize(roaring_bitmap_t *ra, uint32_t *serialize_len) {
-    uint8_t retry_with_array;
-    char *ret =
-        ra_serialize(ra->high_low_container, serialize_len, &retry_with_array);
-
-    if (retry_with_array) {
-        /*
-           In this case, space-wise, it's more efficient to represent the bitmap
-           as an array of uint32_t rather than a serialized bitmap.
-        */
-        free(ret);
-        uint64_t cardinality = roaring_bitmap_get_cardinality(ra);
-
-        unsigned char *a =
-            (unsigned char *)malloc(cardinality * sizeof(uint32_t) + 1);
-        if (a == NULL) return NULL;
-        *serialize_len = 1 + cardinality * sizeof(uint32_t);
-        roaring_bitmap_to_uint32_array(ra, (uint32_t *)a);
-        memmove(a + 1, a, cardinality * sizeof(uint32_t));
-        a[0] = SERIALIZATION_ARRAY_UINT32;
-        return ((char *)a);
-    } else
-        return (ret);
+size_t roaring_bitmap_serialize(const roaring_bitmap_t *ra, char *buf) {
+	size_t portablesize = roaring_bitmap_portable_size_in_bytes(ra);
+	uint64_t cardinality = roaring_bitmap_get_cardinality(ra);
+	size_t sizeasarray = cardinality * sizeof(uint32_t) + sizeof(uint32_t);
+	if(portablesize < sizeasarray) {
+		buf[0] = SERIALIZATION_CONTAINER;
+    	return roaring_bitmap_portable_serialize(ra, buf + 1) + 1;
+	} else {
+		buf[0] = SERIALIZATION_ARRAY_UINT32;
+        memcpy(buf + 1, &cardinality, sizeof(uint32_t));
+        roaring_bitmap_to_uint32_array(ra, (uint32_t *)(buf + 1 + sizeof(uint32_t)));
+        return 1 + sizeasarray;
+	}
 }
 
+
+size_t roaring_bitmap_size_in_bytes(const roaring_bitmap_t *ra) {
+	size_t portablesize = roaring_bitmap_portable_size_in_bytes(ra);
+	size_t sizeasarray = roaring_bitmap_get_cardinality(ra) * sizeof(uint32_t) + sizeof(uint32_t);
+    return portablesize < sizeasarray ? portablesize + 1 : sizeasarray + 1;
+}
+
+
 size_t roaring_bitmap_portable_size_in_bytes(const roaring_bitmap_t *ra) {
-    return ra_portable_size_in_bytes(ra->high_low_container);
+    return ra_portable_size_in_bytes(& ra->high_low_container);
 }
 
 roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf) {
@@ -7032,66 +7324,40 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf) {
     if (ans == NULL) {
         return NULL;
     }
-    ans->high_low_container =
-        ra_portable_deserialize(buf);  // todo: handle the case where it is NULL
+    bool is_ok =  ra_portable_deserialize(& ans->high_low_container, buf);
     ans->copy_on_write = false;
+    if(! is_ok) {
+      roaring_bitmap_free(ans);
+      return NULL;
+    }
     return ans;
 }
 
 size_t roaring_bitmap_portable_serialize(const roaring_bitmap_t *ra,
                                          char *buf) {
-    return ra_portable_serialize(ra->high_low_container, buf);
+    return ra_portable_serialize(& ra->high_low_container, buf);
 }
 
-roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf,
-                                             uint32_t buf_len) {
-    roaring_bitmap_t *b;
-
-    if (buf_len < 4) return (NULL);
-
+roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf) {
+	const char * bufaschar = (const char *) buf;
     if (*(const unsigned char *)buf == SERIALIZATION_ARRAY_UINT32) {
-        /* This looks like a compressed set of uint32_t elements */
-        uint32_t i, card = (buf_len - 1) / sizeof(uint32_t);
-        const uint32_t *elems = (const uint32_t *)((const char *)buf + 1);
+    	/* This looks like a compressed set of uint32_t elements */
+        uint32_t card;
+        memcpy(&card, bufaschar + 1, sizeof(uint32_t));
+        const uint32_t *elems = (const uint32_t *)(bufaschar + 1 + sizeof(uint32_t));
 
-        b = roaring_bitmap_create();
-
-        for (i = 0; i < card; i++) {
-            uint32_t val;
-            memcpy(&val, elems + i, sizeof(val));
-            roaring_bitmap_add(b, val);
-        }
-        return (b);
-    } else if (*(const unsigned char *)buf == SERIALIZATION_CONTAINER) {
-        uint32_t len;
-
-        memcpy(&len, &((const unsigned char *)buf)[1], 4);
-
-        if (len != buf_len) return (NULL);
-
-        b = (roaring_bitmap_t *)malloc(sizeof(roaring_bitmap_t));
-        if (b) {
-            b->high_low_container =
-                ra_deserialize((const char *)buf + 5, buf_len - 5);
-            if (b->high_low_container == NULL) {
-                free(b);
-                b = NULL;
-            }
-        }
-        b->copy_on_write = false;
-
-        return (b);
+        return roaring_bitmap_of_ptr(card, elems);
+    } else if (bufaschar[0] == SERIALIZATION_CONTAINER) {
+    	return roaring_bitmap_portable_deserialize(bufaschar + 1);
     } else
         return (NULL);
 }
 
 bool roaring_iterate(const roaring_bitmap_t *ra, roaring_iterator iterator,
                      void *ptr) {
-    for (int i = 0; i < ra->high_low_container->size; ++i)
-        if (!container_iterate(
-                ra->high_low_container->containers[i],
-                ra->high_low_container->typecodes[i],
-                ((uint32_t)ra->high_low_container->keys[i]) << 16, iterator,
+    for (int i = 0; i < ra->high_low_container.size; ++i)
+        if (!container_iterate(ra->high_low_container.containers[i], ra->high_low_container.typecodes[i],
+                ((uint32_t)ra->high_low_container.keys[i]) << 16, iterator,
                 ptr)) {
             return false;
         }
@@ -7099,20 +7365,17 @@ bool roaring_iterate(const roaring_bitmap_t *ra, roaring_iterator iterator,
 }
 
 bool roaring_bitmap_equals(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2) {
-    if (ra1->high_low_container->size != ra2->high_low_container->size) {
+    if (ra1->high_low_container.size != ra2->high_low_container.size) {
         return false;
     }
-    for (int i = 0; i < ra1->high_low_container->size; ++i) {
-        if (ra1->high_low_container->keys[i] !=
-            ra2->high_low_container->keys[i]) {
+    for (int i = 0; i < ra1->high_low_container.size; ++i) {
+        if (ra1->high_low_container.keys[i] !=
+            ra2->high_low_container.keys[i]) {
             return false;
         }
     }
-    for (int i = 0; i < ra1->high_low_container->size; ++i) {
-        bool areequal = container_equals(ra1->high_low_container->containers[i],
-                                         ra1->high_low_container->typecodes[i],
-                                         ra2->high_low_container->containers[i],
-                                         ra2->high_low_container->typecodes[i]);
+    for (int i = 0; i < ra1->high_low_container.size; ++i) {
+        bool areequal = container_equals( ra1->high_low_container.containers[i], ra1->high_low_container.typecodes[i], ra2->high_low_container.containers[i], ra2->high_low_container.typecodes[i]);
         if (!areequal) {
             return false;
         }
@@ -7121,7 +7384,7 @@ bool roaring_bitmap_equals(roaring_bitmap_t *ra1, roaring_bitmap_t *ra2) {
 }
 
 static void insert_flipped_container(roaring_array_t *ans_arr,
-                                     roaring_array_t *x1_arr, uint16_t hb,
+                                     const roaring_array_t *x1_arr, uint16_t hb,
                                      uint16_t lb_start, uint16_t lb_end) {
     const int i = ra_get_index(x1_arr, hb);
     const int j = ra_get_index(ans_arr, hb);
@@ -7176,7 +7439,7 @@ static void inplace_flip_container(roaring_array_t *x1_arr, uint16_t hb,
 }
 
 static void insert_fully_flipped_container(roaring_array_t *ans_arr,
-                                           roaring_array_t *x1_arr,
+                                           const roaring_array_t *x1_arr,
                                            uint16_t hb) {
     const int i = ra_get_index(x1_arr, hb);
     const int j = ra_get_index(ans_arr, hb);
@@ -7239,18 +7502,16 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
     uint16_t hb_end = (uint16_t)((range_end - 1) >> 16);
     const uint16_t lb_end = (uint16_t)(range_end - 1);  // & 0xFFFF;
 
-    ra_append_copies_until(ans->high_low_container, x1->high_low_container,
+    ra_append_copies_until(& ans->high_low_container, & x1->high_low_container,
                            hb_start, x1->copy_on_write);
     if (hb_start == hb_end) {
-        insert_flipped_container(ans->high_low_container,
-                                 x1->high_low_container, hb_start, lb_start,
+        insert_flipped_container(& ans->high_low_container, & x1->high_low_container, hb_start, lb_start,
                                  lb_end);
     } else {
         // start and end containers are distinct
         if (lb_start > 0) {
             // handle first (partial) container
-            insert_flipped_container(ans->high_low_container,
-                                     x1->high_low_container, hb_start, lb_start,
+            insert_flipped_container(& ans->high_low_container, & x1->high_low_container, hb_start, lb_start,
                                      0xFFFF);
             ++hb_start;  // for the full containers.  Can't wrap.
         }
@@ -7258,19 +7519,17 @@ roaring_bitmap_t *roaring_bitmap_flip(const roaring_bitmap_t *x1,
         if (lb_end != 0xFFFF) --hb_end;  // later we'll handle the partial block
 
         for (uint16_t hb = hb_start; hb <= hb_end; ++hb) {
-            insert_fully_flipped_container(ans->high_low_container,
-                                           x1->high_low_container, hb);
+            insert_fully_flipped_container(& ans->high_low_container, & x1->high_low_container, hb);
         }
 
         // handle a partial final container
         if (lb_end != 0xFFFF) {
-            insert_flipped_container(ans->high_low_container,
-                                     x1->high_low_container, hb_end + 1, 0,
+            insert_flipped_container(& ans->high_low_container, & x1->high_low_container, hb_end + 1, 0,
                                      lb_end);
             ++hb_end;
         }
     }
-    ra_append_copies_after(ans->high_low_container, x1->high_low_container,
+    ra_append_copies_after(& ans->high_low_container, & x1->high_low_container,
                            hb_end, x1->copy_on_write);
     return ans;
 }
@@ -7287,13 +7546,13 @@ void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
     const uint16_t lb_end = (uint16_t)(range_end - 1);
 
     if (hb_start == hb_end) {
-        inplace_flip_container(x1->high_low_container, hb_start, lb_start,
+        inplace_flip_container(& x1->high_low_container, hb_start, lb_start,
                                lb_end);
     } else {
         // start and end containers are distinct
         if (lb_start > 0) {
             // handle first (partial) container
-            inplace_flip_container(x1->high_low_container, hb_start, lb_start,
+            inplace_flip_container(& x1->high_low_container, hb_start, lb_start,
                                    0xFFFF);
             ++hb_start;  // for the full containers.  Can't wrap.
         }
@@ -7301,12 +7560,12 @@ void roaring_bitmap_flip_inplace(roaring_bitmap_t *x1, uint64_t range_start,
         if (lb_end != 0xFFFF) --hb_end;
 
         for (uint16_t hb = hb_start; hb <= hb_end; ++hb) {
-            inplace_fully_flip_container(x1->high_low_container, hb);
+            inplace_fully_flip_container(& x1->high_low_container, hb);
         }
 
         // handle a partial final container
         if (lb_end != 0xFFFF) {
-            inplace_flip_container(x1->high_low_container, hb_end + 1, 0,
+            inplace_flip_container(& x1->high_low_container, hb_end + 1, 0,
                                    lb_end);
             ++hb_end;
         }
@@ -7317,8 +7576,8 @@ roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *x1,
                                          const roaring_bitmap_t *x2,
                                          const bool bitsetconversion) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     roaring_bitmap_t *answer =
         roaring_bitmap_create_with_capacity(length1 + length2);
     answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -7330,13 +7589,13 @@ roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c;
             if (bitsetconversion && (get_container_type(c1, container_type_1) !=
@@ -7361,48 +7620,48 @@ roaring_bitmap_t *roaring_bitmap_lazy_or(const roaring_bitmap_t *x1,
             // the
             // result here
             // can only be non-empty
-            ra_append(answer->high_low_container, s1, c, container_result_type);
+            ra_append(& answer->high_low_container, s1, c, container_result_type);
             ++pos1;
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 =
                 get_copy_of_container(c1, &container_type_1, x1->copy_on_write);
             if (x1->copy_on_write) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c1,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c1,
                                           container_type_1);
             }
-            ra_append(answer->high_low_container, s1, c1, container_type_1);
+            ra_append(& answer->high_low_container, s1, c1, container_type_1);
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_append(answer->high_low_container, s2, c2, container_type_2);
+            ra_append(& answer->high_low_container, s2, c2, container_type_2);
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(answer->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     } else if (pos2 == length2) {
-        ra_append_copy_range(answer->high_low_container, x1->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x1->high_low_container,
                              pos1, length1, x1->copy_on_write);
     }
     return answer;
@@ -7412,8 +7671,8 @@ void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
                                     const roaring_bitmap_t *x2,
                                     const bool bitsetconversion) {
     uint8_t container_result_type = 0;
-    int length1 = x1->high_low_container->size;
-    const int length2 = x2->high_low_container->size;
+    int length1 = x1->high_low_container.size;
+    const int length2 = x2->high_low_container.size;
 
     if (0 == length2) return;
 
@@ -7423,11 +7682,11 @@ void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             if ((bitsetconversion == false) ||
                 (get_container_type(c1, container_type_1) ==
@@ -7443,7 +7702,7 @@ void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
                 container_type_1 = BITSET_CONTAINER_TYPE_CODE;
             }
 
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c =
                 container_lazy_ior(c1, container_type_1, c2, container_type_2,
@@ -7453,41 +7712,41 @@ void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
                 container_free(c1, container_type_1);
             }
 
-            ra_set_container_at_index(x1->high_low_container, pos1, c,
+            ra_set_container_at_index(& x1->high_low_container, pos1, c,
                                       container_result_type);
             ++pos1;
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             // void *c2_clone = container_clone(c2, container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_insert_new_key_value_at(x1->high_low_container, pos1, s2, c2,
+            ra_insert_new_key_value_at(& x1->high_low_container, pos1, s2, c2,
                                        container_type_2);
             pos1++;
             length1++;
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(x1->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& x1->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     }
 }
@@ -7495,8 +7754,8 @@ void roaring_bitmap_lazy_or_inplace(roaring_bitmap_t *x1,
 roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *x1,
                                           const roaring_bitmap_t *x2) {
     uint8_t container_result_type = 0;
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
+    const int length1 = x1->high_low_container.size,
+              length2 = x2->high_low_container.size;
     roaring_bitmap_t *answer =
         roaring_bitmap_create_with_capacity(length1 + length2);
     answer->copy_on_write = x1->copy_on_write && x2->copy_on_write;
@@ -7509,20 +7768,20 @@ roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *x1,
 
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c =
                 container_lazy_xor(c1, container_type_1, c2, container_type_2,
                                    &container_result_type);
 
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_append(answer->high_low_container, s1, c,
+                ra_append(& answer->high_low_container, s1, c,
                           container_result_type);
             } else {
                 container_free(c, container_result_type);
@@ -7532,43 +7791,43 @@ roaring_bitmap_t *roaring_bitmap_lazy_xor(const roaring_bitmap_t *x1,
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 =
                 get_copy_of_container(c1, &container_type_1, x1->copy_on_write);
             if (x1->copy_on_write) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c1,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c1,
                                           container_type_1);
             }
-            ra_append(answer->high_low_container, s1, c1, container_type_1);
+            ra_append(& answer->high_low_container, s1, c1, container_type_1);
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_append(answer->high_low_container, s2, c2, container_type_2);
+            ra_append(& answer->high_low_container, s2, c2, container_type_2);
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(answer->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     } else if (pos2 == length2) {
-        ra_append_copy_range(answer->high_low_container, x1->high_low_container,
+        ra_append_copy_range(& answer->high_low_container, & x1->high_low_container,
                              pos1, length1, x1->copy_on_write);
     }
     return answer;
@@ -7578,8 +7837,8 @@ void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
                                      const roaring_bitmap_t *x2) {
     assert(x1 != x2);
     uint8_t container_result_type = 0;
-    int length1 = x1->high_low_container->size;
-    const int length2 = x2->high_low_container->size;
+    int length1 = x1->high_low_container.size;
+    const int length2 = x2->high_low_container.size;
 
     if (0 == length2) return;
 
@@ -7589,72 +7848,72 @@ void roaring_bitmap_lazy_xor_inplace(roaring_bitmap_t *x1,
     }
     int pos1 = 0, pos2 = 0;
     uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+    uint16_t s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+    uint16_t s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
     while (true) {
         if (s1 == s2) {
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
+            void *c1 = ra_get_container_at_index(& x1->high_low_container, pos1,
                                                  &container_type_1);
             c1 = get_writable_copy_if_shared(c1, &container_type_1);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             void *c =
                 container_lazy_ixor(c1, container_type_1, c2, container_type_2,
                                     &container_result_type);
             if (container_nonzero_cardinality(c, container_result_type)) {
-                ra_set_container_at_index(x1->high_low_container, pos1, c,
+                ra_set_container_at_index(& x1->high_low_container, pos1, c,
                                           container_result_type);
                 ++pos1;
             } else {
                 container_free(c, container_result_type);
-                ra_remove_at_index(x1->high_low_container, pos1);
+                ra_remove_at_index(& x1->high_low_container, pos1);
                 --length1;
             }
             ++pos2;
             if (pos1 == length1) break;
             if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
 
         } else if (s1 < s2) {  // s1 < s2
             pos1++;
             if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
+            s1 = ra_get_key_at_index(& x1->high_low_container, pos1);
 
         } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
+            void *c2 = ra_get_container_at_index(& x2->high_low_container, pos2,
                                                  &container_type_2);
             // void *c2_clone = container_clone(c2, container_type_2);
             c2 =
                 get_copy_of_container(c2, &container_type_2, x2->copy_on_write);
             if (x2->copy_on_write) {
-                ra_set_container_at_index(x2->high_low_container, pos2, c2,
+                ra_set_container_at_index(& x2->high_low_container, pos2, c2,
                                           container_type_2);
             }
-            ra_insert_new_key_value_at(x1->high_low_container, pos1, s2, c2,
+            ra_insert_new_key_value_at(& x1->high_low_container, pos1, s2, c2,
                                        container_type_2);
             pos1++;
             length1++;
             pos2++;
             if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
+            s2 = ra_get_key_at_index(& x2->high_low_container, pos2);
         }
     }
     if (pos1 == length1) {
-        ra_append_copy_range(x1->high_low_container, x2->high_low_container,
+        ra_append_copy_range(& x1->high_low_container, & x2->high_low_container,
                              pos2, length2, x2->copy_on_write);
     }
 }
 
 void roaring_bitmap_repair_after_lazy(roaring_bitmap_t *ra) {
-    for (int i = 0; i < ra->high_low_container->size; ++i) {
-        const uint8_t original_typecode = ra->high_low_container->typecodes[i];
-        void *container = ra->high_low_container->containers[i];
+    for (int i = 0; i < ra->high_low_container.size; ++i) {
+        const uint8_t original_typecode = ra->high_low_container.typecodes[i];
+        void *container = ra->high_low_container.containers[i];
         uint8_t new_typecode = original_typecode;
         void *newcontainer =
             container_repair_after_lazy(container, &new_typecode);
-        ra->high_low_container->containers[i] = newcontainer;
-        ra->high_low_container->typecodes[i] = new_typecode;
+        ra->high_low_container.containers[i] = newcontainer;
+        ra->high_low_container.typecodes[i] = new_typecode;
     }
 }
 
@@ -7666,24 +7925,24 @@ bool roaring_bitmap_select(const roaring_bitmap_t *bm, uint32_t rank,
     uint32_t start_rank = 0;
     int i = 0;
     bool valid = false;
-    while (!valid && i < bm->high_low_container->size) {
-        container = bm->high_low_container->containers[i];
-        typecode = bm->high_low_container->typecodes[i];
+    while (!valid && i < bm->high_low_container.size) {
+        container = bm->high_low_container.containers[i];
+        typecode = bm->high_low_container.typecodes[i];
         valid =
             container_select(container, typecode, &start_rank, rank, element);
         i++;
     }
 
     if (valid) {
-        key = bm->high_low_container->keys[i - 1];
+        key = bm->high_low_container.keys[i - 1];
         *element |= (key << 16);
         return true;
     } else
         return false;
 }
-/* end file /Users/saulius/repos/CRoaring/src/roaring.c */
-/* begin file /Users/saulius/repos/CRoaring/src/roaring_array.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/roaring_array.c"
+/* end file /home/dlemire/CVS/github/CRoaring/src/roaring.c */
+/* begin file /home/dlemire/CVS/github/CRoaring/src/roaring_array.c */
+#line 8 "/home/dlemire/CVS/github/CRoaring/src/roaring_array.c"
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -7691,153 +7950,175 @@ bool roaring_bitmap_select(const roaring_bitmap_t *bm, uint32_t rank,
 #include <string.h>
 
 
-// ported from RoaringArray.java
-// Todo: optimization (eg branchless binary search)
-// Go version has copy-on-write, has combo binary/sequential search
-// AND: fast SIMD and on key sets; containerwise AND; SIMD partial sum
-//    with +1 for nonempty containers, 0 for empty containers
-//    then use this to pack the arrays for the result.
 
 // Convention: [0,ra->size) all elements are initialized
 //  [ra->size, ra->allocation_size) is junk and contains nothing needing freeing
 
-extern inline int32_t ra_get_size(roaring_array_t *ra);
-extern inline int32_t ra_get_index(roaring_array_t *ra, uint16_t x);
-extern inline void *ra_get_container_at_index(roaring_array_t *ra, 
+extern inline int32_t ra_get_size(const roaring_array_t *ra);
+extern inline int32_t ra_get_index(const roaring_array_t *ra, uint16_t x);
+extern inline void *ra_get_container_at_index(const roaring_array_t *ra,
       uint16_t i, uint8_t *typecode);
+extern inline void ra_unshare_container_at_index(roaring_array_t *ra, uint16_t i);
+extern inline void ra_replace_key_and_container_at_index(roaring_array_t *ra, int32_t i,
+        uint16_t key, void *c,
+        uint8_t typecode);
+extern inline void ra_set_container_at_index(const roaring_array_t *ra, int32_t i, void *c,
+                               uint8_t typecode);
+
+
+
 #define INITIAL_CAPACITY 4
 
-roaring_array_t *ra_create_with_capacity(uint32_t cap) {
-    roaring_array_t *new_ra =
-        (roaring_array_t *)malloc(sizeof(roaring_array_t));
-    if (!new_ra) return NULL;
+static bool realloc_array(roaring_array_t *ra, size_t new_capacity) {
+    // because we combine the allocations, it is not possible to use realloc
+	/*ra->keys =
+        (uint16_t *)realloc(ra->keys, sizeof(uint16_t) * new_capacity);
+    ra->containers =
+        (void **)realloc(ra->containers, sizeof(void *) * new_capacity);
+    ra->typecodes =
+        (uint8_t *)realloc(ra->typecodes, sizeof(uint8_t) * new_capacity);
+    if (!ra->keys || !ra->containers || !ra->typecodes) {
+    	free(ra->keys);
+    	free(ra->containers);
+    	free(ra->typecodes);
+    	return false;
+    }*/
+	const size_t memoryneeded = new_capacity * (sizeof(uint16_t)+sizeof(void *)+sizeof(uint8_t));
+	void * bigalloc = malloc(memoryneeded);
+	if(! bigalloc) return false;
+	void** newcontainers = (void **) bigalloc;
+	uint16_t * newkeys = (uint16_t *)(newcontainers + new_capacity);
+	uint8_t * newtypecodes = (uint8_t *)(newkeys + new_capacity);
+	assert((char *)(newtypecodes + new_capacity) == (char *) bigalloc + memoryneeded);
+    memcpy(newcontainers,ra->containers,sizeof(void *) * ra->size);
+    memcpy(newkeys,ra->keys,sizeof(uint16_t) * ra->size);
+    memcpy(newtypecodes, ra->typecodes,sizeof(uint8_t) * ra->size);
+	ra->containers = newcontainers;
+	ra->keys = newkeys;
+	ra->typecodes = newtypecodes;
+	ra->allocation_size = new_capacity;
+    return true;
+}
+
+
+bool ra_init_with_capacity(roaring_array_t *new_ra, uint32_t cap) {
+    if (!new_ra) return false;
     new_ra->keys = NULL;
     new_ra->containers = NULL;
     new_ra->typecodes = NULL;
 
     new_ra->allocation_size = cap;
-    new_ra->keys = (uint16_t *)malloc(cap * sizeof(uint16_t));
-    new_ra->containers = (void **)malloc(cap * sizeof(void *));
-    new_ra->typecodes = (uint8_t *)malloc(cap * sizeof(uint8_t));
-    if (!new_ra->keys || !new_ra->containers || !new_ra->typecodes) {
-        free(new_ra);
-        free(new_ra->keys);
-        free(new_ra->containers);
-        free(new_ra->typecodes);
-        return NULL;
-    }
+    void * bigalloc = malloc(cap * (sizeof(uint16_t)+sizeof(void *)+sizeof(uint8_t)));
+    new_ra->containers = (void **) bigalloc;
+    new_ra->keys = (uint16_t *)(new_ra->containers + cap);
+    new_ra->typecodes = (uint8_t *)(new_ra->keys + cap);
     new_ra->size = 0;
 
-    return new_ra;
+    return true;
+}
+bool ra_init(roaring_array_t * t) {
+	return ra_init_with_capacity(t, INITIAL_CAPACITY);
 }
 
-roaring_array_t *ra_create() {
-    return ra_create_with_capacity(INITIAL_CAPACITY);
-}
 
-roaring_array_t *ra_copy(roaring_array_t *r, bool copy_on_write) {
-    roaring_array_t *new_ra =
-        (roaring_array_t *)malloc(sizeof(roaring_array_t));
-    if (!new_ra) return NULL;
-    new_ra->keys = NULL;
-    new_ra->containers = NULL;
-    new_ra->typecodes = NULL;
 
-    const int32_t allocsize = r->allocation_size;
-    new_ra->allocation_size = allocsize;
-    new_ra->keys = (uint16_t *)malloc(allocsize * sizeof(uint16_t));
-    new_ra->containers =
-        (void **)calloc(allocsize, sizeof(void *));  // setting pointers to zero
-    new_ra->typecodes = (uint8_t *)malloc(allocsize * sizeof(uint8_t));
-    if (!new_ra->keys || !new_ra->containers || !new_ra->typecodes) {
-        free(new_ra);
-        free(new_ra->keys);
-        free(new_ra->containers);
-        free(new_ra->typecodes);
-        return NULL;
-    }
-    int32_t s = r->size;
-    new_ra->size = s;
-    memcpy(new_ra->keys, r->keys, s * sizeof(uint16_t));
+bool ra_copy(const roaring_array_t *source, roaring_array_t * dest, bool copy_on_write) {
+	if(! ra_init_with_capacity(dest, source->size)) return false;
+	dest->size = source->size;
+	dest->allocation_size = source->size;
+    memcpy(dest->keys, source->keys, dest->size * sizeof(uint16_t));
     // we go through the containers, turning them into shared containers...
     if (copy_on_write) {
-        for (int32_t i = 0; i < s; ++i) {
-            r->containers[i] = get_copy_of_container(
-                r->containers[i], &r->typecodes[i], copy_on_write);
+        for (int32_t i = 0; i < dest->size; ++i) {
+            source->containers[i] = get_copy_of_container(
+            		source->containers[i], &source->typecodes[i], copy_on_write);
         }
         // we do a shallow copy to the other bitmap
-        memcpy(new_ra->containers, r->containers, s * sizeof(void *));
-        memcpy(new_ra->typecodes, r->typecodes, s * sizeof(uint8_t));
+        memcpy(dest->containers, source->containers, dest->size * sizeof(void *));
+        memcpy(dest->typecodes, source->typecodes, dest->size * sizeof(uint8_t));
     } else {
-        memcpy(new_ra->typecodes, r->typecodes, s * sizeof(uint8_t));
-        for (int32_t i = 0; i < s; i++) {
-            new_ra->containers[i] =
-                container_clone(r->containers[i], r->typecodes[i]);
-            if (new_ra->containers[i] == NULL) {
+        memcpy(dest->typecodes, source->typecodes, dest->size * sizeof(uint8_t));
+        for (int32_t i = 0; i < dest->size; i++) {
+            dest->containers[i] =
+                container_clone(source->containers[i], source->typecodes[i]);
+            if (dest->containers[i] == NULL) {
                 for (int32_t j = 0; j < i; j++) {
-                    container_free(r->containers[j], r->typecodes[j]);
+                    container_free(dest->containers[j], dest->typecodes[j]);
                 }
-                free(new_ra);
-                free(new_ra->keys);
-                free(new_ra->containers);
-                free(new_ra->typecodes);
-                return NULL;
+                ra_clear_without_containers(dest);
+                return false;
             }
         }
     }
-    return new_ra;
+    return true;
 }
 
-static void ra_clear(roaring_array_t *ra) {
-    free(ra->keys);
-    ra->keys = NULL;  // paranoid
-    for (int i = 0; i < ra->size; ++i) {
+
+bool ra_overwrite(const roaring_array_t *source, roaring_array_t * dest, bool copy_on_write) {
+	ra_clear_containers(dest); // we are going to overwrite them
+	if(dest->allocation_size < source->size) {
+		if(! realloc_array(dest, source->size)) {
+			return false;
+		}
+	}
+	dest->size = source->size;
+    memcpy(dest->keys, source->keys, dest->size * sizeof(uint16_t));
+    // we go through the containers, turning them into shared containers...
+    if (copy_on_write) {
+        for (int32_t i = 0; i < dest->size; ++i) {
+            source->containers[i] = get_copy_of_container(
+                source->containers[i], &source->typecodes[i], copy_on_write);
+        }
+        // we do a shallow copy to the other bitmap
+        memcpy(dest->containers, source->containers, dest->size * sizeof(void *));
+        memcpy(dest->typecodes, source->typecodes, dest->size * sizeof(uint8_t));
+    } else {
+        memcpy(dest->typecodes, source->typecodes, dest->size * sizeof(uint8_t));
+        for (int32_t i = 0; i < dest->size; i++) {
+            dest->containers[i] =
+                container_clone(source->containers[i], source->typecodes[i]);
+            if (dest->containers[i] == NULL) {
+                for (int32_t j = 0; j < i; j++) {
+                    container_free(dest->containers[j], dest->typecodes[j]);
+                }
+                ra_clear_without_containers(dest);
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+void ra_clear_containers(roaring_array_t *ra) {
+    for (int32_t i = 0; i < ra->size; ++i) {
         container_free(ra->containers[i], ra->typecodes[i]);
     }
-    free(ra->containers);
-    ra->containers = NULL;  // paranoid
-    free(ra->typecodes);
-    ra->typecodes = NULL;  // paranoid
 }
 
-static void ra_clear_without_containers(roaring_array_t *ra) {
-    free(ra->keys);
+void ra_clear_without_containers(roaring_array_t *ra) {
+	free(ra->containers); // keys and typecodes are allocated with containers
     ra->keys = NULL;  // paranoid
-    free(ra->containers);
     ra->containers = NULL;  // paranoid
-    free(ra->typecodes);
     ra->typecodes = NULL;  // paranoid
 }
 
-void ra_free(roaring_array_t *ra) {
-    ra_clear(ra);
-    free(ra);
-}
-
-void ra_free_without_containers(roaring_array_t *ra) {
+void ra_clear(roaring_array_t *ra) {
+    ra_clear_containers(ra);
     ra_clear_without_containers(ra);
-    free(ra);
 }
 
-void extend_array(roaring_array_t *ra, uint32_t k) {
-    // corresponding Java code uses >= ??
-    int desired_size = ra->size + (int)k;
+
+
+
+bool extend_array(roaring_array_t *ra, int32_t k) {
+	int32_t desired_size = ra->size + k;
     if (desired_size > ra->allocation_size) {
-        int new_capacity =
+        size_t new_capacity =
             (ra->size < 1024) ? 2 * desired_size : 5 * desired_size / 4;
 
-        ra->keys =
-            (uint16_t *)realloc(ra->keys, sizeof(uint16_t) * new_capacity);
-        ra->containers =
-            (void **)realloc(ra->containers, sizeof(void *) * new_capacity);
-        ra->typecodes =
-            (uint8_t *)realloc(ra->typecodes, sizeof(uint8_t) * new_capacity);
-        if (!ra->keys || !ra->containers || !ra->typecodes) {
-            fprintf(stderr, "[%s] %s\n", __FILE__, __func__);
-            perror(0);
-        }
-        ra->allocation_size = new_capacity;
+        return realloc_array(ra, new_capacity);
     }
+    return true;
 }
 
 void ra_append(roaring_array_t *ra, uint16_t key, void *container,
@@ -7851,7 +8132,7 @@ void ra_append(roaring_array_t *ra, uint16_t key, void *container,
     ra->size++;
 }
 
-void ra_append_copy(roaring_array_t *ra, roaring_array_t *sa, uint16_t index,
+void ra_append_copy(roaring_array_t *ra, const roaring_array_t *sa, uint16_t index,
                     bool copy_on_write) {
     extend_array(ra, 1);
     const int32_t pos = ra->size;
@@ -7872,7 +8153,7 @@ void ra_append_copy(roaring_array_t *ra, roaring_array_t *sa, uint16_t index,
     ra->size++;
 }
 
-void ra_append_copies_until(roaring_array_t *ra, roaring_array_t *sa,
+void ra_append_copies_until(roaring_array_t *ra, const roaring_array_t *sa,
                             uint16_t stopping_key, bool copy_on_write) {
     for (uint16_t i = 0; i < sa->size; ++i) {
         if (sa->keys[i] >= stopping_key) break;
@@ -7880,7 +8161,7 @@ void ra_append_copies_until(roaring_array_t *ra, roaring_array_t *sa,
     }
 }
 
-void ra_append_copy_range(roaring_array_t *ra, roaring_array_t *sa,
+void ra_append_copy_range(roaring_array_t *ra, const roaring_array_t *sa,
                           uint16_t start_index, uint16_t end_index,
                           bool copy_on_write) {
     extend_array(ra, end_index - start_index);
@@ -7902,7 +8183,7 @@ void ra_append_copy_range(roaring_array_t *ra, roaring_array_t *sa,
     }
 }
 
-void ra_append_copies_after(roaring_array_t *ra, roaring_array_t *sa,
+void ra_append_copies_after(roaring_array_t *ra, const roaring_array_t *sa,
                             uint16_t before_start, bool copy_on_write) {
     int start_location = ra_get_index(sa, before_start);
     if (start_location >= 0)
@@ -7955,7 +8236,7 @@ void *ra_get_container(roaring_array_t *ra, uint16_t x, uint8_t *typecode) {
     return ra->containers[i];
 }
 
-extern void *ra_get_container_at_index(roaring_array_t *ra, uint16_t i,
+extern void *ra_get_container_at_index(const roaring_array_t *ra, uint16_t i,
                                        uint8_t *typecode);
 
 void *ra_get_writable_container(roaring_array_t *ra, uint16_t x,
@@ -7973,13 +8254,13 @@ void *ra_get_writable_container_at_index(roaring_array_t *ra, uint16_t i,
     return get_writable_copy_if_shared(ra->containers[i], typecode);
 }
 
-uint16_t ra_get_key_at_index(roaring_array_t *ra, uint16_t i) {
+uint16_t ra_get_key_at_index(const roaring_array_t *ra, uint16_t i) {
     return ra->keys[i];
 }
 
-extern int32_t ra_get_index(roaring_array_t *ra, uint16_t x);
+extern int32_t ra_get_index(const roaring_array_t *ra, uint16_t x);
 
-extern int32_t ra_advance_until(roaring_array_t *ra, uint16_t x, int32_t pos);
+extern int32_t ra_advance_until(const roaring_array_t *ra, uint16_t x, int32_t pos);
 
 // everything skipped over is freed
 int32_t ra_advance_until_freeing(roaring_array_t *ra, uint16_t x, int32_t pos) {
@@ -8054,210 +8335,41 @@ void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
             sizeof(uint8_t) * range);
 }
 
-void ra_set_container_at_index(roaring_array_t *ra, int32_t i, void *c,
-                               uint8_t typecode) {
-    assert(i < ra->size);
-    ra->containers[i] = c;
-    ra->typecodes[i] = typecode;
-}
 
-void ra_replace_key_and_container_at_index(roaring_array_t *ra, int32_t i,
-                                           uint16_t key, void *c,
-                                           uint8_t typecode) {
-    assert(i < ra->size);
 
-    ra->keys[i] = key;
-    ra->containers[i] = c;
-    ra->typecodes[i] = typecode;
-}
-
-// just for debugging use
-void show_structure(roaring_array_t *ra) {
-    for (int i = 0; i < ra->size; ++i) {
-        printf(" i=%d\n", i);
-        fflush(stdout);
-
-        printf("Container %d has key %d and its type is %s  of card %d\n", i,
-               (int)ra->keys[i],
-               get_full_container_name(ra->containers[i], ra->typecodes[i]),
-               container_get_cardinality(ra->containers[i], ra->typecodes[i]));
-    }
-}
-
-char *ra_serialize(roaring_array_t *ra, uint32_t *serialize_len,
-                   uint8_t *retry_with_array) {
-    uint32_t off, l,
-        cardinality = 0,
+size_t ra_size_in_bytes(roaring_array_t *ra) {
+    size_t cardinality = 0;
+    size_t
         tot_len =
             1 /* initial byte type */ + 4 /* tot_len */ +
             sizeof(roaring_array_t) +
             ra->size * (sizeof(uint16_t) + sizeof(void *) + sizeof(uint8_t));
-    char *out;
-    uint16_t *lens;
-
-    (*retry_with_array) = 0;
-    /* [ 32 bit length ] [ serialization bytes ] */
-    if ((lens = (uint16_t *)malloc(sizeof(int16_t) * ra->size)) == NULL) {
-        *serialize_len = 0;
-        return (NULL);
-    }
-
     for (int32_t i = 0; i < ra->size; i++) {
-        lens[i] =
-            container_serialization_len(ra->containers[i], ra->typecodes[i]);
-
-        assert(lens[i] != 0);
-        tot_len += (lens[i] + sizeof(lens[i]));
+        tot_len += (container_serialization_len(ra->containers[i], ra->typecodes[i]) + sizeof(uint16_t));
         cardinality +=
             container_get_cardinality(ra->containers[i], ra->typecodes[i]);
     }
 
-    if ((cardinality * sizeof(uint32_t)) < tot_len) {
-        *retry_with_array = 1;
-        free(lens);
-        return (NULL);
+    if ((cardinality * sizeof(uint32_t) + sizeof(uint32_t)) < tot_len) {
+        return cardinality * sizeof(uint32_t) + 1 + sizeof(uint32_t);
     }
-
-    out = (char *)malloc(tot_len);
-
-    if (out == NULL) {
-        free(lens);
-        *serialize_len = 0;
-        return (NULL);
-    } else
-        *serialize_len = tot_len;
-
-    /* Leave room for the first byte */
-    out[0] = SERIALIZATION_CONTAINER, off = 1;
-
-    /* Total lenght (first 4 bytes of the serialization) */
-    memcpy(out + off, &tot_len, 4), off += 4;
-
-    l = sizeof(roaring_array_t);
-    uint32_t saved_allocation_size = ra->allocation_size;
-
-    ra->allocation_size = ra->size;
-    memcpy(&out[off], ra, l);
-    ra->allocation_size = saved_allocation_size;
-    off += l;
-
-    l = ra->size * sizeof(uint16_t);
-    memcpy(&out[off], ra->keys, l);
-    off += l;
-
-    l = ra->size * sizeof(void *);
-    memcpy(&out[off], ra->containers, l);
-    off += l;
-
-    l = ra->size * sizeof(uint8_t);
-    memcpy(&out[off], ra->typecodes, l);
-    off += l;
-
-    for (int32_t i = 0; i < ra->size; i++) {
-        int32_t serialized_bytes;
-
-        memcpy(&out[off], &lens[i], sizeof(lens[i]));
-        off += sizeof(lens[i]);
-        serialized_bytes =
-            container_serialize(ra->containers[i], ra->typecodes[i], &out[off]);
-
-        if (serialized_bytes != lens[i]) {
-            for (int32_t j = 0; j <= i; j++)
-                container_free(ra->containers[j], ra->typecodes[j]);
-
-            free(lens);
-            free(out);
-            assert(serialized_bytes != lens[i]);
-            return (NULL);
-        }
-
-        off += serialized_bytes;
-    }
-
-    if (tot_len != off) {
-        assert(tot_len != off);
-    }
-
-    free(lens);
-
-    return (out);
+    return tot_len;
 }
 
-roaring_array_t *ra_deserialize(const void *buf, uint32_t buf_len) {
-    int32_t size;
-    const char *bufaschar = (const char *)buf;
-    memcpy(&size, bufaschar, sizeof(int32_t));
-    roaring_array_t *ra_copy;
-    uint32_t off, l;
-    uint32_t expected_len =
-        sizeof(roaring_array_t) +
-        size * (sizeof(uint16_t) + sizeof(void *) + sizeof(uint8_t));
 
-    if (buf_len < expected_len) return (NULL);
 
-    if ((ra_copy = (roaring_array_t *)malloc(sizeof(roaring_array_t))) == NULL)
-        return (NULL);
-
-    memcpy(ra_copy, bufaschar, off = sizeof(roaring_array_t));
-
-    if ((ra_copy->keys = (uint16_t *)malloc(size * sizeof(uint16_t))) == NULL) {
-        free(ra_copy);
-        return (NULL);
+void ra_to_uint32_array(const roaring_array_t *ra, uint32_t *ans) {
+    size_t ctr = 0;
+    for (int i = 0; i < ra->size; ++i) {
+        int num_added = container_to_uint32_array(
+            ans + ctr, ra->containers[i],
+            ra->typecodes[i],
+            ((uint32_t)ra->keys[i]) << 16);
+        ctr += num_added;
     }
-
-    if ((ra_copy->containers = (void **)malloc(size * sizeof(void *))) ==
-        NULL) {
-        free(ra_copy->keys);
-        free(ra_copy);
-        return (NULL);
-    }
-
-    if ((ra_copy->typecodes = (uint8_t *)malloc(size * sizeof(uint8_t))) ==
-        NULL) {
-        free(ra_copy->containers);
-        free(ra_copy->keys);
-        free(ra_copy);
-        return (NULL);
-    }
-
-    l = size * sizeof(uint16_t);
-    memcpy(ra_copy->keys, &bufaschar[off], l);
-    off += l;
-
-    l = size * sizeof(void *);
-    memcpy(ra_copy->containers, &bufaschar[off], l);
-    off += l;
-
-    l = size * sizeof(uint8_t);
-    memcpy(ra_copy->typecodes, &bufaschar[off], l);
-    off += l;
-
-    for (int32_t i = 0; i < size; i++) {
-        uint16_t len;
-
-        memcpy(&len, &bufaschar[off], sizeof(len));
-        off += sizeof(len);
-
-        ra_copy->containers[i] =
-            container_deserialize(ra_copy->typecodes[i], &bufaschar[off], len);
-
-        if (ra_copy->containers[i] == NULL) {
-            for (int32_t j = 0; j < i; j++)
-                container_free(ra_copy->containers[j], ra_copy->typecodes[j]);
-
-            free(ra_copy->containers);
-            free(ra_copy->keys);
-            free(ra_copy);
-            return (NULL);
-        }
-
-        off += len;
-    }
-
-    return (ra_copy);
 }
 
-bool ra_has_run_container(roaring_array_t *ra) {
+bool ra_has_run_container(const roaring_array_t *ra) {
     for (int32_t k = 0; k < ra->size; ++k) {
         if (get_container_type(ra->containers[k], ra->typecodes[k]) ==
             RUN_CONTAINER_TYPE_CODE)
@@ -8266,7 +8378,7 @@ bool ra_has_run_container(roaring_array_t *ra) {
     return false;
 }
 
-uint32_t ra_portable_header_size(roaring_array_t *ra) {
+uint32_t ra_portable_header_size(const roaring_array_t *ra) {
     if (ra_has_run_container(ra)) {
         if (ra->size <
             NO_OFFSET_THRESHOLD) {  // for small bitmaps, we omit the offsets
@@ -8279,7 +8391,7 @@ uint32_t ra_portable_header_size(roaring_array_t *ra) {
     }
 }
 
-size_t ra_portable_size_in_bytes(roaring_array_t *ra) {
+size_t ra_portable_size_in_bytes(const roaring_array_t *ra) {
     size_t count = ra_portable_header_size(ra);
 
     for (int32_t k = 0; k < ra->size; ++k) {
@@ -8288,8 +8400,7 @@ size_t ra_portable_size_in_bytes(roaring_array_t *ra) {
     return count;
 }
 
-size_t ra_portable_serialize(roaring_array_t *ra, char *buf) {
-    assert(!IS_BIG_ENDIAN);  // not implemented
+size_t ra_portable_serialize(const roaring_array_t *ra, char *buf) {
     char *initbuf = buf;
     uint32_t startOffset = 0;
     bool hasrun = ra_has_run_container(ra);
@@ -8349,8 +8460,7 @@ size_t ra_portable_serialize(roaring_array_t *ra, char *buf) {
     return buf - initbuf;
 }
 
-roaring_array_t *ra_portable_deserialize(const char *buf) {
-    assert(!IS_BIG_ENDIAN);  // not implemented
+bool ra_portable_deserialize(roaring_array_t *answer, const char *buf) {
     uint32_t cookie;
     memcpy(&cookie, buf, sizeof(int32_t));
     buf += sizeof(uint32_t);
@@ -8358,7 +8468,7 @@ roaring_array_t *ra_portable_deserialize(const char *buf) {
         cookie != SERIAL_COOKIE_NO_RUNCONTAINER) {
         fprintf(stderr, "I failed to find one of the right cookies. Found %d\n",
                 cookie);
-        return NULL;
+        return false;
     }
     int32_t size;
 
@@ -8368,10 +8478,10 @@ roaring_array_t *ra_portable_deserialize(const char *buf) {
         memcpy(&size, buf, sizeof(int32_t));
         buf += sizeof(uint32_t);
     }
-    roaring_array_t *answer = ra_create_with_capacity(size);
-    if (answer == NULL) {
+    bool is_ok = ra_init_with_capacity(answer, size);
+    if (!is_ok) {
         fprintf(stderr, "Failed to allocate memory early on. Bailing out.\n");
-        return answer;
+        return false;
     }
     answer->size = size;
     char *bitmapOfRunContainers = NULL;
@@ -8384,10 +8494,9 @@ roaring_array_t *ra_portable_deserialize(const char *buf) {
         buf += s;
     }
     uint16_t *keys = answer->keys;
-    int32_t *cardinalities = (int32_t *)malloc(size * sizeof(int32_t));
+    int32_t *cardinalities = (int32_t *)malloc(size * (sizeof(int32_t) + sizeof(bool)));// one malloc
     assert(cardinalities != NULL);  // todo: handle
-    bool *isBitmap = (bool *)malloc(size * sizeof(bool));
-    assert(isBitmap != NULL);  // todo: handle
+    bool *isBitmap = (bool *)(cardinalities + size);
     uint16_t tmp;
     for (int32_t k = 0; k < size; ++k) {
         memcpy(&keys[k], buf, sizeof(keys[k]));
@@ -8430,252 +8539,8 @@ roaring_array_t *ra_portable_deserialize(const char *buf) {
         }
     }
     free(bitmapOfRunContainers);
-    free(cardinalities);
-    free(isBitmap);
-    return answer;
+    free(cardinalities);//isBitmap fits in there
+    return true;
 }
 
-void ra_unshare_container_at_index(roaring_array_t *ra, uint16_t i) {
-    assert(i < ra->size);
-    ra->containers[i] =
-        get_writable_copy_if_shared(ra->containers[i], &ra->typecodes[i]);
-}
-/* end file /Users/saulius/repos/CRoaring/src/roaring_array.c */
-/* begin file /Users/saulius/repos/CRoaring/src/roaring_priority_queue.c */
-#line 8 "/Users/saulius/repos/CRoaring/src/roaring_priority_queue.c"
-
-struct roaring_pq_element_s {
-    uint64_t size;
-    bool is_temporary;
-    roaring_bitmap_t *bitmap;
-};
-
-typedef struct roaring_pq_element_s roaring_pq_element_t;
-
-struct roaring_pq_s {
-    roaring_pq_element_t *elements;
-    uint64_t size;
-};
-
-typedef struct roaring_pq_s roaring_pq_t;
-
-static inline bool compare(roaring_pq_element_t *t1, roaring_pq_element_t *t2) {
-    return t1->size < t2->size;
-}
-
-static void pq_add(roaring_pq_t *pq, roaring_pq_element_t *t) {
-    uint64_t i = pq->size;
-    pq->elements[pq->size++] = *t;
-    while (i > 0) {
-        uint64_t p = (i - 1) >> 1;
-        roaring_pq_element_t ap = pq->elements[p];
-        if (!compare(t, &ap)) break;
-        pq->elements[i] = ap;
-        i = p;
-    }
-    pq->elements[i] = *t;
-}
-
-static void pq_free(roaring_pq_t *pq) {
-    free(pq->elements);
-    pq->elements = NULL;  // paranoid
-    free(pq);
-}
-
-static void percolate_down(roaring_pq_t *pq, uint32_t i) {
-    uint32_t size = pq->size;
-    uint32_t hsize = size >> 1;
-    roaring_pq_element_t ai = pq->elements[i];
-    while (i < hsize) {
-        uint32_t l = (i << 1) + 1;
-        uint32_t r = l + 1;
-        roaring_pq_element_t bestc = pq->elements[l];
-        if (r < size) {
-            if (compare(pq->elements + r, &bestc)) {
-                l = r;
-                bestc = pq->elements[r];
-            }
-        }
-        if (!compare(&bestc, &ai)) {
-            break;
-        }
-        pq->elements[i] = bestc;
-        i = l;
-    }
-    pq->elements[i] = ai;
-}
-
-static roaring_pq_t *create_pq(const roaring_bitmap_t **arr, uint32_t length) {
-    roaring_pq_t *answer = (roaring_pq_t *)malloc(sizeof(roaring_pq_t));
-    answer->elements =
-        (roaring_pq_element_t *)malloc(sizeof(roaring_pq_element_t) * length);
-    answer->size = length;
-    for (uint32_t i = 0; i < length; i++) {
-        answer->elements[i].bitmap = (roaring_bitmap_t *)arr[i];
-        answer->elements[i].is_temporary = false;
-        answer->elements[i].size =
-            roaring_bitmap_portable_size_in_bytes(arr[i]);
-    }
-    for (int32_t i = (length >> 1); i >= 0; i--) {
-        percolate_down(answer, i);
-    }
-    return answer;
-}
-
-static roaring_pq_element_t pq_poll(roaring_pq_t *pq) {
-    roaring_pq_element_t ans = *pq->elements;
-    if (pq->size > 1) {
-        pq->elements[0] = pq->elements[--pq->size];
-        percolate_down(pq, 0);
-    } else
-        --pq->size;
-    // memmove(pq->elements,pq->elements+1,(pq->size-1)*sizeof(roaring_pq_element_t));--pq->size;
-    return ans;
-}
-
-// this function consumes and frees the inputs
-static roaring_bitmap_t *lazy_or_from_lazy_inputs(roaring_bitmap_t *x1,
-                                                  roaring_bitmap_t *x2) {
-    uint8_t container_result_type = 0;
-    roaring_bitmap_t *answer = roaring_bitmap_create();
-    const int length1 = x1->high_low_container->size,
-              length2 = x2->high_low_container->size;
-    if (0 == length1) {
-        roaring_bitmap_free(x1);
-        return x2;
-    }
-    if (0 == length2) {
-        roaring_bitmap_free(x2);
-        return x1;
-    }
-    int pos1 = 0, pos2 = 0;
-    uint8_t container_type_1, container_type_2;
-    uint16_t s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-    uint16_t s2 = ra_get_key_at_index(x2->high_low_container, pos2);
-    while (true) {
-        if (s1 == s2) {
-            // todo: unsharing can be inefficient as it may create a clone where
-            // none
-            // is needed, but it has the benefit of being easy to reason about.
-            ra_unshare_container_at_index(x1->high_low_container, pos1);
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
-                                                 &container_type_1);
-            assert(container_type_1 != SHARED_CONTAINER_TYPE_CODE);
-            ra_unshare_container_at_index(x2->high_low_container, pos2);
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
-                                                 &container_type_2);
-            assert(container_type_2 != SHARED_CONTAINER_TYPE_CODE);
-            void *c;
-
-            if ((container_type_2 == BITSET_CONTAINER_TYPE_CODE) &&
-                (container_type_2 != BITSET_CONTAINER_TYPE_CODE)) {
-                c = container_lazy_ior(c2, container_type_2, c1,
-                                       container_type_1,
-                                       &container_result_type);
-                container_free(c1, container_type_1);
-                if (c != c2) {
-                    container_free(c2, container_type_2);
-                }
-            } else {
-                c = container_lazy_ior(c1, container_type_1, c2,
-                                       container_type_2,
-                                       &container_result_type);
-                container_free(c2, container_type_2);
-                if (c != c1) {
-                    container_free(c1, container_type_1);
-                }
-            }
-            // since we assume that the initial containers are non-empty, the
-            // result here
-            // can only be non-empty
-            ra_append(answer->high_low_container, s1, c, container_result_type);
-            ++pos1;
-            ++pos2;
-            if (pos1 == length1) break;
-            if (pos2 == length2) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
-
-        } else if (s1 < s2) {  // s1 < s2
-            void *c1 = ra_get_container_at_index(x1->high_low_container, pos1,
-                                                 &container_type_1);
-            ra_append(answer->high_low_container, s1, c1, container_type_1);
-            pos1++;
-            if (pos1 == length1) break;
-            s1 = ra_get_key_at_index(x1->high_low_container, pos1);
-
-        } else {  // s1 > s2
-            void *c2 = ra_get_container_at_index(x2->high_low_container, pos2,
-                                                 &container_type_2);
-            ra_append(answer->high_low_container, s2, c2, container_type_2);
-            pos2++;
-            if (pos2 == length2) break;
-            s2 = ra_get_key_at_index(x2->high_low_container, pos2);
-        }
-    }
-    if (pos1 == length1) {
-        ra_append_move_range(answer->high_low_container, x2->high_low_container,
-                             pos2, length2);
-    } else if (pos2 == length2) {
-        ra_append_move_range(answer->high_low_container, x1->high_low_container,
-                             pos1, length1);
-    }
-    ra_free_without_containers(x1->high_low_container);
-    ra_free_without_containers(x2->high_low_container);
-    free(x1);
-    free(x2);
-    return answer;
-}
-
-/**
- * Compute the union of 'number' bitmaps using a heap. This can
- * sometimes be faster than roaring_bitmap_or_many which uses
- * a naive algorithm. Caller is responsible for freeing the
- * result.
- */
-roaring_bitmap_t *roaring_bitmap_or_many_heap(uint32_t number,
-                                              const roaring_bitmap_t **x) {
-    if (number == 0) {
-        return roaring_bitmap_create();
-    }
-    if (number == 1) {
-        return roaring_bitmap_copy(x[0]);
-    }
-    roaring_pq_t *pq = create_pq(x, number);
-    while (pq->size > 1) {
-        roaring_pq_element_t x1 = pq_poll(pq);
-        roaring_pq_element_t x2 = pq_poll(pq);
-
-        if (x1.is_temporary && x2.is_temporary) {
-            roaring_bitmap_t *newb =
-                lazy_or_from_lazy_inputs(x1.bitmap, x2.bitmap);
-            uint64_t bsize = roaring_bitmap_portable_size_in_bytes(newb);
-            roaring_pq_element_t newelement = {
-                .size = bsize, .is_temporary = true, .bitmap = newb};
-            pq_add(pq, &newelement);
-        } else if (x2.is_temporary) {
-            roaring_bitmap_lazy_or_inplace(x2.bitmap, x1.bitmap, false);
-            x2.size = roaring_bitmap_portable_size_in_bytes(x2.bitmap);
-            pq_add(pq, &x2);
-        } else if (x1.is_temporary) {
-            roaring_bitmap_lazy_or_inplace(x1.bitmap, x2.bitmap, false);
-            x1.size = roaring_bitmap_portable_size_in_bytes(x1.bitmap);
-
-            pq_add(pq, &x1);
-        } else {
-            roaring_bitmap_t *newb =
-                roaring_bitmap_lazy_or(x1.bitmap, x2.bitmap, false);
-            uint64_t bsize = roaring_bitmap_portable_size_in_bytes(newb);
-            roaring_pq_element_t newelement = {
-                .size = bsize, .is_temporary = true, .bitmap = newb};
-
-            pq_add(pq, &newelement);
-        }
-    }
-    roaring_pq_element_t X = pq_poll(pq);
-    roaring_bitmap_t *answer = X.bitmap;
-    roaring_bitmap_repair_after_lazy(answer);
-    pq_free(pq);
-    return answer;
-}
-/* end file /Users/saulius/repos/CRoaring/src/roaring_priority_queue.c */
+/* end file /home/dlemire/CVS/github/CRoaring/src/roaring_array.c */

--- a/croaring-sys/CRoaring/roaring.h
+++ b/croaring-sys/CRoaring/roaring.h
@@ -1,6 +1,6 @@
-/* auto-generated on Mon Aug 22 21:49:42 EEST 2016. Do not edit! */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/portability.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/portability.h"
+/* auto-generated on Fri Sep  2 21:26:08 EDT 2016. Do not edit! */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/portability.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/portability.h"
 /*
  * portability.h
  *
@@ -85,9 +85,9 @@ static inline int hamming(uint64_t x) {
 #endif
 
 #endif /* INCLUDE_PORTABILITY_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/portability.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/perfparameters.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/perfparameters.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/portability.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/perfparameters.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/perfparameters.h"
 #ifndef PERFPARAMETERS_H_
 #define PERFPARAMETERS_H_
 
@@ -112,9 +112,9 @@ enum { ARRAY_DEFAULT_INIT_SIZE = 16 };
 #endif
 
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/perfparameters.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/array_util.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/array_util.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/perfparameters.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/array_util.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/array_util.h"
 #ifndef ARRAY_UTIL_H
 #define ARRAY_UTIL_H
 
@@ -249,9 +249,9 @@ size_t union_uint32_card(const uint32_t *set_1, size_t size_1,
                          const uint32_t *set_2, size_t size_2);
 
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/array_util.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/roaring_types.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/roaring_types.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/array_util.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring_types.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/roaring_types.h"
 /*
   Typedefs used by various components
 */
@@ -300,255 +300,9 @@ typedef struct roaring_statistics_s {
 } roaring_statistics_t;
 
 #endif /* ROARING_TYPES_H */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/roaring_types.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/roaring_array.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/roaring_array.h"
-#ifndef INCLUDE_ROARING_ARRAY_H
-#define INCLUDE_ROARING_ARRAY_H
-
-#include <stdbool.h>
-#include <stdint.h>
-
-#define MAX_CONTAINERS 65536
-
-#define SERIALIZATION_ARRAY_UINT32 1
-#define SERIALIZATION_CONTAINER 2
-
-enum {
-    SERIAL_COOKIE_NO_RUNCONTAINER = 12346,
-    SERIAL_COOKIE = 12347,
-    NO_OFFSET_THRESHOLD = 4
-};
-
-/**
- * Roaring arrays are array-based key-value pairs having containers as values
- * and 16-bit integer keys. A roaring bitmap  might be implemented as such.
- */
-
-// parallel arrays.  Element sizes quite different.
-// Alternative is array
-// of structs.  Which would have better
-// cache performance through binary searches?
-
-typedef struct roaring_array_s {
-    int32_t size;
-    int32_t allocation_size;
-    uint16_t *keys;
-    void **containers;
-    uint8_t *typecodes;
-    uint8_t *shared; /* for COW, used as a bitset*/
-} roaring_array_t;
-
-/**
- * Create a new roaring array
- */
-roaring_array_t *ra_create(void);
-
-/**
- * Create a new roaring array with the specified capacity (in number
- * of containers)
- */
-roaring_array_t *ra_create_with_capacity(uint32_t cap);
-
-/**
- * Copies this roaring array (caller is responsible for memory management)
- */
-roaring_array_t *ra_copy(roaring_array_t *r, bool copy_on_write);
-
-/**
- * Frees the memory used by a roaring array
- */
-void ra_free(roaring_array_t *r);
-
-/**
- * Frees the memory used by a roaring array, but does not free the containers
- */
-void ra_free_without_containers(roaring_array_t *r);
-
-/**
- * Get the index corresponding to a 16-bit key
- */
-inline int32_t ra_get_index(roaring_array_t *ra, uint16_t x) {
-    if ((ra->size == 0) || ra->keys[ra->size - 1] == x) return ra->size - 1;
-
-    return binarySearch(ra->keys, (int32_t)ra->size, x);
-}
-
-/**
- * Retrieves the container at index i, filling in the typecode
- */
-inline void *ra_get_container_at_index(roaring_array_t *ra, uint16_t i,
-                                              uint8_t *typecode) {
-    *typecode = ra->typecodes[i];
-    return ra->containers[i];
-}
-
-/**
- * Retrieves the key at index i
- */
-uint16_t ra_get_key_at_index(roaring_array_t *ra, uint16_t i);
-
-/**
- * Add a new key-value pair at index i
- */
-void ra_insert_new_key_value_at(roaring_array_t *ra, int32_t i, uint16_t key,
-                                void *container, uint8_t typecode);
-
-/**
- * Append a new key-value pair
- */
-void ra_append(roaring_array_t *ra, uint16_t s, void *c, uint8_t typecode);
-
-/**
- * Append a new key-value pair to ra, cloning (in COW sense) a value from sa
- * at index index
- */
-void ra_append_copy(roaring_array_t *ra, roaring_array_t *sa, uint16_t index,
-                    bool copy_on_write);
-
-/**
- * Append new key-value pairs to ra, cloning (in COW sense)  values from sa
- * at indexes
- * [start_index, uint16_t end_index)
- */
-void ra_append_copy_range(roaring_array_t *ra, roaring_array_t *sa,
-                          uint16_t start_index, uint16_t end_index,
-                          bool copy_on_write);
-
-/** appends from sa to ra, ending with the greatest key that is
- * is less or equal stopping_key
- */
-void ra_append_copies_until(roaring_array_t *ra, roaring_array_t *sa,
-                            uint16_t stopping_key, bool copy_on_write);
-
-/** appends from sa to ra, starting with the smallest key that is
- * is strictly greater than before_start
- */
-
-void ra_append_copies_after(roaring_array_t *ra, roaring_array_t *sa,
-                            uint16_t before_start, bool copy_on_write);
-
-/**
- * Move the key-value pairs to ra from sa at indexes
- * [start_index, uint16_t end_index), old array should not be freed
- * (use ra_free_without_containers)
- **/
-void ra_append_move_range(roaring_array_t *ra, roaring_array_t *sa,
-                          uint16_t start_index, uint16_t end_index);
-/**
- * Append new key-value pairs to ra,  from sa at indexes
- * [start_index, uint16_t end_index)
- */
-void ra_append_range(roaring_array_t *ra, roaring_array_t *sa,
-                     uint16_t start_index, uint16_t end_index,
-                     bool copy_on_write);
-
-/**
- * Set the container at the corresponding index using the specified
- * typecode.
- */
-void ra_set_container_at_index(roaring_array_t *ra, int32_t i, void *c,
-                               uint8_t typecode);
-
-/**
- * If needed, increase the capacity of the array so that it can fit k values
- * (at
- * least);
- */
-void extend_array(roaring_array_t *ra, uint32_t k);
-
-inline int32_t ra_get_size(roaring_array_t *ra) { return ra->size; }
-
-static inline int32_t ra_advance_until(roaring_array_t *ra, uint16_t x,
-                                       int32_t pos) {
-    return advanceUntil(ra->keys, pos, ra->size, x);
-}
-
-int32_t ra_advance_until_freeing(roaring_array_t *ra, uint16_t x, int32_t pos);
-
-void ra_downsize(roaring_array_t *ra, int32_t new_length);
-
-void ra_replace_key_and_container_at_index(roaring_array_t *ra, int32_t i,
-                                           uint16_t key, void *c,
-                                           uint8_t typecode);
-
-// see ra_portable_serialize if you want a format that's compatible with
-// Java
-// and Go implementations
-char *ra_serialize(roaring_array_t *ra, uint32_t *serialize_len,
-                   uint8_t *retry_with_array);
-
-// see ra_portable_serialize if you want a format that's compatible with
-// Java
-// and Go implementations
-roaring_array_t *ra_deserialize(const void *buf, uint32_t buf_len);
-
-/**
- * write a bitmap to a buffer. This is meant to be compatible with
- * the
- * Java and Go versions. Return the size in bytes of the serialized
- * output (which should be ra_portable_size_in_bytes(ra)).
- */
-size_t ra_portable_serialize(roaring_array_t *ra, char *buf);
-
-/**
- * read a bitmap from a serialized version. This is meant to be compatible
- * with
- * the
- * Java and Go versions.
- */
-roaring_array_t *ra_portable_deserialize(const char *buf);
-
-/**
- * How many bytes are required to serialize this bitmap (meant to be
- * compatible
- * with Java and Go versions)
- */
-size_t ra_portable_size_in_bytes(roaring_array_t *ra);
-
-/**
- * return true if it contains at least one run container.
- */
-bool ra_has_run_container(roaring_array_t *ra);
-
-/**
- * Size of the header when serializing (meant to be compatible
- * with Java and Go versions)
- */
-uint32_t ra_portable_header_size(roaring_array_t *ra);
-
-/**
- * If the container at the index i is share, unshare it (creating a local
- * copy if needed).
- */
-void ra_unshare_container_at_index(roaring_array_t *ra, uint16_t i);
-
-/**
- * remove at index i, sliding over all entries after i
- */
-void ra_remove_at_index(roaring_array_t *ra, int32_t i);
-
-/**
- * remove at index i, sliding over all entries after i. Free removed container.
- */
-void ra_remove_at_index_and_free(roaring_array_t *ra, int32_t i);
-
-/**
- * remove a chunk of indices, sliding over entries after it
- */
-// void ra_remove_index_range(roaring_array_t *ra, int32_t begin, int32_t end);
-
-// used in inplace andNot only, to slide left the containers from
-// the mutated RoaringBitmap that are after the largest container of
-// the argument RoaringBitmap.  It is followed by a call to resize.
-//
-void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
-                   uint32_t new_begin);
-
-#endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/roaring_array.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/utilasm.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/utilasm.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring_types.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/utilasm.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/utilasm.h"
 /*
  * utilasm.h
  *
@@ -617,9 +371,9 @@ void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
 
 #endif  // USE_BMI
 #endif  /* INCLUDE_UTILASM_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/utilasm.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/bitset_util.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/bitset_util.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/utilasm.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/bitset_util.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/bitset_util.h"
 #ifndef BITSET_UTIL_H
 #define BITSET_UTIL_H
 
@@ -711,7 +465,7 @@ static inline void bitset_reset_range(uint64_t *bitmap, uint32_t start,
  * This function uses AVX2 decoding.
  */
 size_t bitset_extract_setbits_avx2(uint64_t *bitset, size_t length,
-                                   uint32_t *out, size_t outcapacity,
+                                   void *vout, size_t outcapacity,
                                    uint32_t base);
 
 /*
@@ -723,7 +477,7 @@ size_t bitset_extract_setbits_avx2(uint64_t *bitset, size_t length,
  *
  * Returns how many values were actually decoded.
  */
-size_t bitset_extract_setbits(uint64_t *bitset, size_t length, uint32_t *out,
+size_t bitset_extract_setbits(uint64_t *bitset, size_t length, void *vout,
                               uint32_t base);
 
 /*
@@ -1114,9 +868,9 @@ AVXPOPCNTFNC(andnot, _mm256_andnot_si256)
 #endif  // USEAVX
 
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/bitset_util.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/array.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/array.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/bitset_util.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/array.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/array.h"
 /*
  * array.h
  *
@@ -1244,7 +998,7 @@ void array_container_negation_inplace(array_container_t *src_dest);
  * The function returns the number of values written.
  * The caller is responsible for allocating enough memory in out.
  */
-int array_container_to_uint32_array(uint32_t *out,
+int array_container_to_uint32_array(void *vout,
                                     const array_container_t *cont,
                                     uint32_t base);
 
@@ -1409,9 +1163,9 @@ inline bool array_container_contains(const array_container_t *arr,
 }
 
 #endif /* INCLUDE_CONTAINERS_ARRAY_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/array.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/bitset.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/bitset.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/array.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/bitset.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/bitset.h"
 /*
  * bitset.h
  *
@@ -1729,7 +1483,7 @@ int bitset_container_andnot_nocard(const bitset_container_t *src_1,
  * The out pointer should point to enough memory (the cardinality times 32
  * bits).
  */
-int bitset_container_to_uint32_array(uint32_t *out,
+int bitset_container_to_uint32_array(void *out,
                                      const bitset_container_t *cont,
                                      uint32_t base);
 
@@ -1808,9 +1562,9 @@ bool bitset_container_select(const bitset_container_t *container,
                              uint32_t *element);
 
 #endif /* INCLUDE_CONTAINERS_BITSET_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/bitset.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/run.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/run.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/bitset.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/run.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/run.h"
 /*
  * run.h
  *
@@ -2111,7 +1865,7 @@ void run_container_xor(const run_container_t *src_1,
  * The function returns the number of values written.
  * The caller is responsible for allocating enough memory in out.
  */
-int run_container_to_uint32_array(uint32_t *out, const run_container_t *cont,
+int run_container_to_uint32_array(void *vout, const run_container_t *cont,
                                   uint32_t base);
 
 /*
@@ -2210,9 +1964,9 @@ void run_container_andnot(const run_container_t *src_1,
                           const run_container_t *src_2, run_container_t *dst);
 
 #endif /* INCLUDE_CONTAINERS_RUN_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/run.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/convert.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/convert.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/run.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/convert.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/convert.h"
 /*
  * convert.h
  *
@@ -2261,9 +2015,9 @@ void *convert_run_to_efficient_container(run_container_t *c,
 void *convert_run_to_efficient_container_and_free(run_container_t *c,
                                                   uint8_t *typecode_after);
 #endif /* INCLUDE_CONTAINERS_CONVERT_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/convert.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_equal.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_equal.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/convert.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_equal.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_equal.h"
 /*
  * mixed_equal.h
  *
@@ -2291,9 +2045,9 @@ bool run_container_equals_bitset(run_container_t* container1,
                                  bitset_container_t* container2);
 
 #endif /* CONTAINERS_MIXED_EQUAL_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_equal.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_andnot.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_andnot.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_equal.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_andnot.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_andnot.h"
 /*
  * mixed_andnot.h
  */
@@ -2451,9 +2205,9 @@ bool bitset_bitset_container_iandnot(bitset_container_t *src_1,
                                      const bitset_container_t *src_2,
                                      void **dst);
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_andnot.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_intersection.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_intersection.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_andnot.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_intersection.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_intersection.h"
 /*
  * mixed_intersection.h
  *
@@ -2513,9 +2267,9 @@ bool bitset_bitset_container_intersection_inplace(
     bitset_container_t *src_1, const bitset_container_t *src_2, void **dst);
 
 #endif /* INCLUDE_CONTAINERS_MIXED_INTERSECTION_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_intersection.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_negation.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_negation.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_intersection.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_negation.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_negation.h"
 /*
  * mixed_negation.h
  *
@@ -2636,9 +2390,9 @@ int run_container_negation_range_inplace(run_container_t *src,
                                          const int range_end, void **dst);
 
 #endif /* INCLUDE_CONTAINERS_MIXED_NEGATION_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_negation.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_union.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_union.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_negation.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_union.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_union.h"
 /*
  * mixed_intersection.h
  *
@@ -2713,9 +2467,9 @@ void run_bitset_container_lazy_union(const run_container_t *src_1,
                                      bitset_container_t *dst);
 
 #endif /* INCLUDE_CONTAINERS_MIXED_UNION_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_union.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_xor.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/mixed_xor.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_union.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_xor.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_xor.h"
 /*
  * mixed_xor.h
  *
@@ -2866,9 +2620,9 @@ bool array_array_container_ixor(array_container_t *src_1,
 int run_run_container_ixor(run_container_t *src_1, const run_container_t *src_2,
                            void **dst);
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/mixed_xor.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/containers/containers.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/containers/containers.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/mixed_xor.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/containers.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/containers/containers.h"
 #ifndef CONTAINERS_CONTAINERS_H
 #define CONTAINERS_CONTAINERS_H
 
@@ -3050,6 +2804,7 @@ static inline const char *get_full_container_name(void *container,
             return "unknown";
     }
     __builtin_unreachable();
+    return NULL;
 }
 
 /**
@@ -4531,6 +4286,9 @@ static inline bool container_iterate(const void *container, uint8_t typecode,
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return false;
 }
 
 static inline void *container_not(const void *c, uint8_t typ,
@@ -4559,6 +4317,9 @@ static inline void *container_not(const void *c, uint8_t typ,
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return NULL;
 }
 
 static inline void *container_not_range(const void *c, uint8_t typ,
@@ -4591,6 +4352,9 @@ static inline void *container_not_range(const void *c, uint8_t typ,
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return NULL;
 }
 
 static inline void *container_inot(void *c, uint8_t typ, uint8_t *result_type) {
@@ -4620,6 +4384,9 @@ static inline void *container_inot(void *c, uint8_t typ, uint8_t *result_type) {
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return NULL;
 }
 
 static inline void *container_inot_range(void *c, uint8_t typ,
@@ -4652,6 +4419,9 @@ static inline void *container_inot_range(void *c, uint8_t typ,
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return NULL;
 }
 
 /**
@@ -4693,12 +4463,286 @@ static inline bool container_select(const void *container, uint8_t typecode,
             assert(false);
             __builtin_unreachable();
     }
+    assert(false);
+    __builtin_unreachable();
+    return false;
 }
 
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/containers/containers.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/misc/configreport.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/misc/configreport.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/containers/containers.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring_array.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/roaring_array.h"
+#ifndef INCLUDE_ROARING_ARRAY_H
+#define INCLUDE_ROARING_ARRAY_H
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#define MAX_CONTAINERS 65536
+
+#define SERIALIZATION_ARRAY_UINT32 1
+#define SERIALIZATION_CONTAINER 2
+
+enum {
+    SERIAL_COOKIE_NO_RUNCONTAINER = 12346,
+    SERIAL_COOKIE = 12347,
+    NO_OFFSET_THRESHOLD = 4
+};
+
+/**
+ * Roaring arrays are array-based key-value pairs having containers as values
+ * and 16-bit integer keys. A roaring bitmap  might be implemented as such.
+ */
+
+// parallel arrays.  Element sizes quite different.
+// Alternative is array
+// of structs.  Which would have better
+// cache performance through binary searches?
+
+typedef struct roaring_array_s {
+    int32_t size;
+    int32_t allocation_size;
+    void **containers;
+    uint16_t *keys;
+    uint8_t *typecodes;
+} roaring_array_t;
+
+/**
+ * Create a new roaring array
+ */
+roaring_array_t *ra_create(void);
+
+/**
+ * Initialize an existing roaring array with the specified capacity (in number
+ * of containers)
+ */
+bool ra_init_with_capacity(roaring_array_t *new_ra, uint32_t cap);
+
+/**
+ * Initialize with default capacity
+ */
+bool ra_init(roaring_array_t * t) ;
+
+/**
+ * Copies this roaring array, we assume that dest is not initialized
+ */
+bool ra_copy(const roaring_array_t *source, roaring_array_t * dest, bool copy_on_write);
+
+/**
+ * Copies this roaring array, we assume that dest is initialized
+ */
+bool ra_overwrite(const roaring_array_t *source, roaring_array_t * dest, bool copy_on_write);
+
+
+/**
+ * Frees the memory used by a roaring array
+ */
+void ra_clear(roaring_array_t *r);
+
+/**
+ * Frees the memory used by a roaring array, but does not free the containers
+ */
+void ra_clear_without_containers(roaring_array_t *r);
+
+
+/**
+ * Frees just the containers
+ */
+void ra_clear_containers(roaring_array_t *ra);
+
+/**
+ * Get the index corresponding to a 16-bit key
+ */
+inline int32_t ra_get_index(const roaring_array_t *ra, uint16_t x) {
+    if ((ra->size == 0) || ra->keys[ra->size - 1] == x) return ra->size - 1;
+
+    return binarySearch(ra->keys, (int32_t)ra->size, x);
+}
+
+/**
+ * Retrieves the container at index i, filling in the typecode
+ */
+inline void *ra_get_container_at_index(const roaring_array_t *ra, uint16_t i,
+                                              uint8_t *typecode) {
+    *typecode = ra->typecodes[i];
+    return ra->containers[i];
+}
+
+/**
+ * Retrieves the key at index i
+ */
+uint16_t ra_get_key_at_index(const roaring_array_t *ra, uint16_t i);
+
+/**
+ * Add a new key-value pair at index i
+ */
+void ra_insert_new_key_value_at(roaring_array_t *ra, int32_t i, uint16_t key,
+                                void *container, uint8_t typecode);
+
+/**
+ * Append a new key-value pair
+ */
+void ra_append(roaring_array_t *ra, uint16_t s, void *c, uint8_t typecode);
+
+/**
+ * Append a new key-value pair to ra, cloning (in COW sense) a value from sa
+ * at index index
+ */
+void ra_append_copy(roaring_array_t *ra, const roaring_array_t *sa, uint16_t index,
+                    bool copy_on_write);
+
+/**
+ * Append new key-value pairs to ra, cloning (in COW sense)  values from sa
+ * at indexes
+ * [start_index, uint16_t end_index)
+ */
+void ra_append_copy_range(roaring_array_t *ra, const roaring_array_t *sa,
+                          uint16_t start_index, uint16_t end_index,
+                          bool copy_on_write);
+
+/** appends from sa to ra, ending with the greatest key that is
+ * is less or equal stopping_key
+ */
+void ra_append_copies_until(roaring_array_t *ra, const roaring_array_t *sa,
+                            uint16_t stopping_key, bool copy_on_write);
+
+/** appends from sa to ra, starting with the smallest key that is
+ * is strictly greater than before_start
+ */
+
+void ra_append_copies_after(roaring_array_t *ra, const roaring_array_t *sa,
+                            uint16_t before_start, bool copy_on_write);
+
+/**
+ * Move the key-value pairs to ra from sa at indexes
+ * [start_index, uint16_t end_index), old array should not be freed
+ * (use ra_clear_without_containers)
+ **/
+void ra_append_move_range(roaring_array_t *ra, roaring_array_t *sa,
+                          uint16_t start_index, uint16_t end_index);
+/**
+ * Append new key-value pairs to ra,  from sa at indexes
+ * [start_index, uint16_t end_index)
+ */
+void ra_append_range(roaring_array_t *ra, roaring_array_t *sa,
+                     uint16_t start_index, uint16_t end_index,
+                     bool copy_on_write);
+
+/**
+ * Set the container at the corresponding index using the specified
+ * typecode.
+ */
+inline void ra_set_container_at_index(const roaring_array_t *ra, int32_t i, void *c,
+                               uint8_t typecode) {
+    assert(i < ra->size);
+    ra->containers[i] = c;
+    ra->typecodes[i] = typecode;
+}
+
+
+/**
+ * If needed, increase the capacity of the array so that it can fit k values
+ * (at
+ * least);
+ */
+bool extend_array(roaring_array_t *ra, int32_t k);
+
+inline int32_t ra_get_size(const roaring_array_t *ra) { return ra->size; }
+
+static inline int32_t ra_advance_until(const roaring_array_t *ra, uint16_t x,
+                                       int32_t pos) {
+    return advanceUntil(ra->keys, pos, ra->size, x);
+}
+
+int32_t ra_advance_until_freeing(roaring_array_t *ra, uint16_t x, int32_t pos);
+
+void ra_downsize(roaring_array_t *ra, int32_t new_length);
+
+inline void ra_replace_key_and_container_at_index(roaring_array_t *ra, int32_t i,
+                                           uint16_t key, void *c,
+                                           uint8_t typecode) {
+    assert(i < ra->size);
+
+    ra->keys[i] = key;
+    ra->containers[i] = c;
+    ra->typecodes[i] = typecode;
+}
+
+// write set bits to an array
+void ra_to_uint32_array(const roaring_array_t *ra, uint32_t *ans);
+
+/**
+ * write a bitmap to a buffer. This is meant to be compatible with
+ * the
+ * Java and Go versions. Return the size in bytes of the serialized
+ * output (which should be ra_portable_size_in_bytes(ra)).
+ */
+size_t ra_portable_serialize(const roaring_array_t *ra, char *buf);
+
+/**
+ * read a bitmap from a serialized version. This is meant to be compatible
+ * with
+ * the
+ * Java and Go versions.
+ */
+bool ra_portable_deserialize(roaring_array_t * ra, const char *buf);
+
+/**
+ * How many bytes are required to serialize this bitmap (meant to be
+ * compatible
+ * with Java and Go versions)
+ */
+size_t ra_portable_size_in_bytes(const roaring_array_t *ra);
+
+/**
+ * return true if it contains at least one run container.
+ */
+bool ra_has_run_container(const roaring_array_t *ra);
+
+/**
+ * Size of the header when serializing (meant to be compatible
+ * with Java and Go versions)
+ */
+uint32_t ra_portable_header_size(const roaring_array_t *ra);
+
+/**
+ * If the container at the index i is share, unshare it (creating a local
+ * copy if needed).
+ */
+static inline void ra_unshare_container_at_index(roaring_array_t *ra, uint16_t i) {
+    assert(i < ra->size);
+    ra->containers[i] =
+        get_writable_copy_if_shared(ra->containers[i], &ra->typecodes[i]);
+}
+
+
+/**
+ * remove at index i, sliding over all entries after i
+ */
+void ra_remove_at_index(roaring_array_t *ra, int32_t i);
+
+/**
+ * remove at index i, sliding over all entries after i. Free removed container.
+ */
+void ra_remove_at_index_and_free(roaring_array_t *ra, int32_t i);
+
+/**
+ * remove a chunk of indices, sliding over entries after it
+ */
+// void ra_remove_index_range(roaring_array_t *ra, int32_t begin, int32_t end);
+
+// used in inplace andNot only, to slide left the containers from
+// the mutated RoaringBitmap that are after the largest container of
+// the argument RoaringBitmap.  It is followed by a call to resize.
+//
+void ra_copy_range(roaring_array_t *ra, uint32_t begin, uint32_t end,
+                   uint32_t new_begin);
+
+#endif
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring_array.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/misc/configreport.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/misc/configreport.h"
 /*
  * configreport.h
  *
@@ -4873,9 +4917,9 @@ static inline void tellmeall() {
 #endif
 
 #endif /* INCLUDE_MISC_CONFIGREPORT_H_ */
-/* end file /Users/saulius/repos/CRoaring/include/roaring/misc/configreport.h */
-/* begin file /Users/saulius/repos/CRoaring/include/roaring/roaring.h */
-#line 8 "/Users/saulius/repos/CRoaring/include/roaring/roaring.h"
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/misc/configreport.h */
+/* begin file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring.h */
+#line 8 "/home/dlemire/CVS/github/CRoaring/include/roaring/roaring.h"
 /*
 An implementation of Roaring Bitmaps in C.
 */
@@ -4889,7 +4933,7 @@ extern "C" {
 #include <stdbool.h>
 
 typedef struct roaring_bitmap_s {
-    roaring_array_t *high_low_container;
+    roaring_array_t high_low_container;
     bool copy_on_write; /* copy_on_write: whether you want to use copy-on-write
                          (saves memory and avoids
                          copies but needs more care in a threaded context). */
@@ -4950,7 +4994,7 @@ roaring_bitmap_t *roaring_bitmap_and(const roaring_bitmap_t *x1,
                                      const roaring_bitmap_t *x2);
 
 /**
- * Inplace version modifies x1.  TODO: decide whether x1 == x2 allowed
+ * Inplace version modifies x1, x1 == x2 is allowed
  */
 void roaring_bitmap_and_inplace(roaring_bitmap_t *x1,
                                 const roaring_bitmap_t *x2);
@@ -5064,19 +5108,13 @@ inline bool roaring_bitmap_contains(const roaring_bitmap_t *r,
      * here it is possible to bypass the binary search and the ra_get_index
      * call with the following call that might often come true
      */
-    int i;
-    if ((r->high_low_container->size > hb) &&
-        (r->high_low_container->keys[hb] == hb))
-        i = hb;  // we got lucky!
-    else {
-        // next call involves a binary search (maybe expensive)
-        i = ra_get_index(r->high_low_container, hb);
-        if (i < 0) return false;
-    }
+    int32_t i = ra_get_index(& r->high_low_container, hb);
+    if (i < 0) return false;
+
     uint8_t typecode;
     // next call ought to be cheap
     void *container =
-        ra_get_container_at_index(r->high_low_container, i, &typecode);
+        ra_get_container_at_index(& r->high_low_container, i, &typecode);
     // rest might be a tad expensive
     return container_contains(container, val & 0xFFFF, typecode);
 }
@@ -5113,13 +5151,32 @@ bool roaring_bitmap_remove_run_compression(roaring_bitmap_t *r);
 */
 bool roaring_bitmap_run_optimize(roaring_bitmap_t *r);
 
+//
+// write the bitmap to an output pointer, this output buffer should refer to
+// at least roaring_bitmap_size_in_bytes(ra) allocated bytes.
+//
 // see roaring_bitmap_portable_serialize if you want a format that's compatible
 // with Java and Go implementations
-char *roaring_bitmap_serialize(roaring_bitmap_t *ra, uint32_t *serialize_len);
+//
+// this format has the benefit of being sometimes more space efficient than roaring_bitmap_portable_serialize
+// e.g., when the data is sparse.
+//
+// Returns how many bytes were written which should be
+// roaring_bitmap_size_in_bytes(ra).
+size_t roaring_bitmap_serialize(const roaring_bitmap_t *ra, char *buf);
 
+//  use with roaring_bitmap_serialize
 // see roaring_bitmap_portable_deserialize if you want a format that's
 // compatible with Java and Go implementations
-roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf, uint32_t buf_len);
+roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf);
+
+
+/**
+ * How many bytes are required to serialize this bitmap (NOT compatible
+ * with Java and Go versions)
+ */
+size_t roaring_bitmap_size_in_bytes(const roaring_bitmap_t *ra);
+
 
 /**
  * read a bitmap from a serialized version. This is meant to be compatible with
@@ -5128,6 +5185,7 @@ roaring_bitmap_t *roaring_bitmap_deserialize(const void *buf, uint32_t buf_len);
  */
 roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf);
 
+
 /**
  * How many bytes are required to serialize this bitmap (meant to be compatible
  * with Java and Go versions)
@@ -5135,7 +5193,9 @@ roaring_bitmap_t *roaring_bitmap_portable_deserialize(const char *buf);
 size_t roaring_bitmap_portable_size_in_bytes(const roaring_bitmap_t *ra);
 
 /**
- * write a bitmap to a char buffer. This is meant to be compatible with
+ * write a bitmap to a char buffer.  The output buffer should refer to at least
+ *  roaring_bitmap_portable_size_in_bytes(ra) bytes of allocated memory.
+ * This is meant to be compatible with
  * the
  * Java and Go versions. Returns how many bytes were written which should be
  * roaring_bitmap_portable_size_in_bytes(ra).
@@ -5258,4 +5318,4 @@ void roaring_bitmap_statistics(const roaring_bitmap_t *ra,
 #endif
 
 #endif
-/* end file /Users/saulius/repos/CRoaring/include/roaring/roaring.h */
+/* end file /home/dlemire/CVS/github/CRoaring/include/roaring/roaring.h */


### PR DESCRIPTION
On Linux, this upgrade improves performance. 

Before:
```bash
$ cargo bench
   Compiling croaring v0.1.0 (file:///home/dlemire/CVS/github/croaring-rs)
    Finished release [optimized] target(s) in 0.67 secs
     Running target/release/benches-cfd8da9312267274

running 30 tests
test bench_add                          ... bench:           8 ns/iter (+/- 0)
test bench_and                          ... bench:         111 ns/iter (+/- 0)
test bench_and_inplace                  ... bench:          14 ns/iter (+/- 0)
test bench_andnot                       ... bench:         112 ns/iter (+/- 0)
test bench_andnot_inplace               ... bench:          13 ns/iter (+/- 0)
test bench_as_slice                     ... bench:          21 ns/iter (+/- 0)
test bench_cardinality_100000           ... bench:           3 ns/iter (+/- 0)
test bench_cardinality_1000000          ... bench:          26 ns/iter (+/- 1)
test bench_contains_false               ... bench:           1 ns/iter (+/- 0)
test bench_contains_true                ... bench:           3 ns/iter (+/- 0)
test bench_create                       ... bench:          65 ns/iter (+/- 0)
test bench_create_with_capacity         ... bench:         220 ns/iter (+/- 0)
test bench_deserialize_100000           ... bench:         757 ns/iter (+/- 2)
test bench_deserialize_1000000          ... bench:       8,649 ns/iter (+/- 848)
test bench_fast_or                      ... bench:       1,100 ns/iter (+/- 0)
test bench_fast_or_heap                 ... bench:         198 ns/iter (+/- 0)
test bench_fast_xor                     ... bench:       1,103 ns/iter (+/- 2)
test bench_flip                         ... bench:         128 ns/iter (+/- 0)
test bench_flip_inplace                 ... bench:          46 ns/iter (+/- 0)
test bench_get_serialized_size_in_bytes ... bench:           6 ns/iter (+/- 0)
test bench_is_empty_false               ... bench:           1 ns/iter (+/- 0)
test bench_is_empty_true                ... bench:           1 ns/iter (+/- 0)
test bench_of                           ... bench:         148 ns/iter (+/- 1)
test bench_or                           ... bench:         119 ns/iter (+/- 0)
test bench_or_inplace                   ... bench:          49 ns/iter (+/- 0)
test bench_remove                       ... bench:           2 ns/iter (+/- 0)
test bench_serialize_100000             ... bench:         269 ns/iter (+/- 3)
test bench_serialize_1000000            ... bench:       4,413 ns/iter (+/- 146)
test bench_xor                          ... bench:         120 ns/iter (+/- 0)
test bench_xor_inplace                  ... bench:          52 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 30 measured

     Running target/release/deps/croaring-84914cfc56235ba2

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```

After:
```bash
$ cargo bench
    Finished release [optimized] target(s) in 0.0 secs
     Running target/release/benches-cfd8da9312267274

running 30 tests
test bench_add                          ... bench:           6 ns/iter (+/- 0)
test bench_and                          ... bench:          74 ns/iter (+/- 0)
test bench_and_inplace                  ... bench:          13 ns/iter (+/- 0)
test bench_andnot                       ... bench:          76 ns/iter (+/- 0)
test bench_andnot_inplace               ... bench:          12 ns/iter (+/- 0)
test bench_as_slice                     ... bench:          21 ns/iter (+/- 0)
test bench_cardinality_100000           ... bench:           4 ns/iter (+/- 0)
test bench_cardinality_1000000          ... bench:          26 ns/iter (+/- 2)
test bench_contains_false               ... bench:           1 ns/iter (+/- 0)
test bench_contains_true                ... bench:           3 ns/iter (+/- 0)
test bench_create                       ... bench:          29 ns/iter (+/- 0)
test bench_create_with_capacity         ... bench:         166 ns/iter (+/- 0)
test bench_deserialize_100000           ... bench:         705 ns/iter (+/- 2)
test bench_deserialize_1000000          ... bench:       6,794 ns/iter (+/- 366)
test bench_fast_or                      ... bench:       1,061 ns/iter (+/- 1)
test bench_fast_or_heap                 ... bench:         162 ns/iter (+/- 0)
test bench_fast_xor                     ... bench:       1,066 ns/iter (+/- 1)
test bench_flip                         ... bench:          92 ns/iter (+/- 0)
test bench_flip_inplace                 ... bench:          45 ns/iter (+/- 0)
test bench_get_serialized_size_in_bytes ... bench:           6 ns/iter (+/- 0)
test bench_is_empty_false               ... bench:           1 ns/iter (+/- 0)
test bench_is_empty_true                ... bench:           1 ns/iter (+/- 0)
test bench_of                           ... bench:          96 ns/iter (+/- 0)
test bench_or                           ... bench:          86 ns/iter (+/- 0)
test bench_or_inplace                   ... bench:          49 ns/iter (+/- 0)
test bench_remove                       ... bench:           2 ns/iter (+/- 0)
test bench_serialize_100000             ... bench:         310 ns/iter (+/- 12)
test bench_serialize_1000000            ... bench:       4,449 ns/iter (+/- 199)
test bench_xor                          ... bench:          83 ns/iter (+/- 0)
test bench_xor_inplace                  ... bench:          48 ns/iter (+/- 0)

test result: ok. 0 passed; 0 failed; 0 ignored; 30 measured

     Running target/release/deps/croaring-84914cfc56235ba2

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured
```


(I do not generally test performance on Macs.)