### PR TITLE
Fix roaring-rs benchmarks to use specialized operators

### DIFF
--- a/benches/performance_comparison.rs
+++ b/benches/performance_comparison.rs
@@ -194,9 +194,7 @@ fn perf_comp_and_new_rust_roaring(b: &mut Bencher) {
     let bitmap2: RoaringBitmap<u32> = (100..200).collect();
 
     b.iter(|| {
-        let bitmap3: RoaringBitmap<u32> = bitmap1.intersection(black_box(&bitmap2)).collect();
-
-        bitmap3
+        &bitmap1 & &bitmap2
     });
 }
 
@@ -236,9 +234,7 @@ fn perf_comp_or_new_rust_roaring(b: &mut Bencher) {
     let bitmap2: RoaringBitmap<u32> = (100..200).collect();
 
     b.iter(|| {
-        let bitmap3: RoaringBitmap<u32> = bitmap1.union(black_box(&bitmap2)).collect();
-
-        bitmap3
+        &bitmap1 | &bitmap2
     });
 }
 
@@ -278,9 +274,7 @@ fn perf_comp_xor_new_rust_roaring(b: &mut Bencher) {
     let bitmap2: RoaringBitmap<u32> = (100..200).collect();
 
     b.iter(|| {
-        let bitmap3: RoaringBitmap<u32> = bitmap1.symmetric_difference(black_box(&bitmap2)).collect();
-
-        bitmap3
+        &bitmap1 ^ &bitmap2
     });
 }
 


### PR DESCRIPTION
First of all, thanks a lot for adding these performance comparison benchmarks 😄 it's great to finally see what the performance of `roaring-rs` is really like.

I was just using these to try and see if all the `#[inline]` attributes I added to `roaring-rs` way back when actually made a difference (surprisingly, yes, quite a big difference) and noticed that there seemed to be a large discrepancy between the `{and,or,xor}_rust_roaring` and `{and,or,xor}_new_rust_roaring` benchmarks, which seemed odd since internally the non-inplace versions of these in `roaring-rs` just clone the bitmap then run the inplace version.

Taking a look I noticed the benchmarks didn't actually call the non-inplace versions, they just collected the iterated variants up. There aren't actually inherent methods on `RoaringBitmap` for the non-inplace version, instead they're just one of the four cases of each binary operator that is implemented. For example [`impl BitOr<&RoaringBitmap> for &RoaringBitmap`](https://docs.rs/roaring/0.4.2/roaring/struct.RoaringBitmap.html#method.bitor-2) is the equivalent to `croaring::Bitmap::or`, it takes in two references and returns a newly allocated `RoaringBitmap` containing the result (whereas the other 3 variants that take in at least one owned `RoaringBitmap` re-use that via the inplace method).

I've opened a couple of my own issues, since looking at the docs now that's really not discoverable, but here's a fix for the benchmarks to use the operators to make the comparison equivalent.