### PR TITLE
Use C api for Bitmap iterator

### DIFF
--- a/benches/performance_comparison.rs
+++ b/benches/performance_comparison.rs
@@ -300,13 +300,13 @@ fn perf_comp_xor_inplace_rust_roaring(b: &mut Bencher) {
 
 #[bench]
 fn perf_comp_iter_croaring(b: &mut Bencher) {
-    let bitmap: Bitmap = (1..10000).collect();
+    let mut bitmap: Bitmap = (1..10000).collect();
 
     b.iter(|| {
         let mut sum: u32 = 0;
 
-        for (_, element) in bitmap.into_iter().enumerate() {
-            sum += *element;
+        for (_, element) in bitmap.iter().enumerate() {
+            sum += element;
         }
 
         assert_eq!(sum, 49995000);

--- a/croaring-sys/src/lib.rs
+++ b/croaring-sys/src/lib.rs
@@ -19,6 +19,18 @@ pub struct roaring_array_s {
 
 #[repr(C)]
 #[derive(Copy, Clone)]
+pub struct roaring_uint32_iterator_s {
+    pub parent: *const roaring_bitmap_s,
+    pub container_index: ::libc::int32_t,
+    pub in_container_index: ::libc::int32_t,
+    pub run_index: ::libc::int32_t,
+    pub in_run_index: ::libc::uint32_t,
+    pub current_value: ::libc::uint32_t,
+    pub has_value: bool
+}
+
+#[repr(C)]
+#[derive(Copy, Clone)]
 pub struct roaring_statistics_s {
     pub n_containers: ::libc::uint32_t,
     pub n_array_containers: ::libc::uint32_t,
@@ -80,11 +92,11 @@ extern "C" {
     pub fn roaring_bitmap_portable_size_in_bytes(ra: *const roaring_bitmap_s) -> ::libc::size_t;
     pub fn roaring_bitmap_portable_serialize(ra: *const roaring_bitmap_s, buf: *mut ::libc::c_char) -> ::libc::size_t;
     pub fn roaring_bitmap_is_empty(ra: *const roaring_bitmap_s) -> bool;
-    /* TODO  pub fn roaring_iterate(ra: *mut roaring_bitmap_s,
-                                    iterator: roaring_iterator,
-                                    ptr: *mut ::libc::c_void) -> bool; */
     pub fn roaring_bitmap_equals(ra1: *const roaring_bitmap_s, ra2: *const roaring_bitmap_s) -> bool;
     pub fn roaring_bitmap_is_subset(ra1: *const roaring_bitmap_s, ra2: *const roaring_bitmap_s) -> bool;
     pub fn roaring_bitmap_is_strict_subset(ra1: *const roaring_bitmap_s, ra2: *const roaring_bitmap_s) -> bool;
     pub fn roaring_bitmap_statistics(ra: *const roaring_bitmap_s, stat: *mut roaring_statistics_s);
+    pub fn roaring_create_iterator(ra: *const roaring_bitmap_s) -> *mut roaring_uint32_iterator_s;
+    pub fn roaring_advance_uint32_iterator(it: *mut roaring_uint32_iterator_s) -> bool;
+    pub fn roaring_free_uint32_iterator(it: *mut roaring_uint32_iterator_s);
 }

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,109 @@
+use std::marker::PhantomData;
+use std::iter::{FromIterator, IntoIterator};
+
+use {Bitmap, ffi};
+
+pub struct BitmapIterator<'a> {
+    iterator: *mut ffi::roaring_uint32_iterator_s,
+    phantom: PhantomData<&'a ()>
+}
+
+impl<'a> BitmapIterator<'a> {
+    fn new(bitmap: &Bitmap) -> Self {
+        BitmapIterator {
+            iterator: unsafe { ffi::roaring_create_iterator(bitmap.bitmap) },
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn current_value(&self) -> Option<u32> {
+        unsafe {
+            if self.has_value() {
+                Some((*self.iterator).current_value)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[inline]
+    fn has_value(&self) -> bool {
+        unsafe {
+            (*self.iterator).has_value
+        }
+    }
+
+    #[inline]
+    fn advance(&mut self) -> bool {
+        unsafe {
+            ffi::roaring_advance_uint32_iterator(self.iterator)
+        }
+    }
+}
+
+impl<'a> Iterator for BitmapIterator<'a> {
+    type Item = u32;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.current_value() {
+            Some(value) => {
+                self.advance();
+
+                Some(value)
+            },
+            None => None
+        }
+    }
+}
+
+impl<'a> Drop for BitmapIterator<'a> {
+    fn drop(&mut self) {
+        unsafe { ffi::roaring_free_uint32_iterator(self.iterator) }
+    }
+}
+
+impl Bitmap {
+    /// Returns an iterator over each value stored in the bitmap.
+    /// Returned values are ordered in ascending order.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Bitmap;
+    ///
+    /// let mut bitmap = Bitmap::create();
+    /// bitmap.add(4);
+    /// bitmap.add(3);
+    /// bitmap.add(2);
+    /// let mut iterator = bitmap.iter();
+    ///
+    /// assert_eq!(iterator.next(), Some(2));
+    /// assert_eq!(iterator.next(), Some(3));
+    /// assert_eq!(iterator.next(), Some(4));
+    /// assert_eq!(iterator.next(), None);
+    /// ```
+    pub fn iter(&self) ->  BitmapIterator {
+        BitmapIterator::new(self)
+    }
+}
+
+impl FromIterator<u32> for Bitmap {
+    /// Convenience method for creating bitmap from iterator.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Bitmap;
+    ///
+    /// let bitmap: Bitmap = (1..3).collect();
+    ///
+    /// assert!(!bitmap.is_empty());
+    /// assert!(bitmap.contains(1));
+    /// assert!(bitmap.contains(2));
+    /// assert_eq!(bitmap.cardinality(), 2);
+    /// ```
+    fn from_iter<I: IntoIterator<Item=u32>>(iter: I) -> Self {
+        Bitmap::of(&Vec::from_iter(iter))
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,3 +64,4 @@ pub type Statistics = ffi::roaring_statistics_s;
 
 mod imp;
 mod ops;
+mod iter;

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,7 +1,6 @@
 use std::slice;
 use std::fmt;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
-use std::iter::{FromIterator, IntoIterator};
 
 use {Bitmap, ffi};
 
@@ -41,49 +40,6 @@ impl Clone for Bitmap {
 impl Drop for Bitmap {
     fn drop(&mut self) {
         unsafe { ffi::roaring_bitmap_free(self.bitmap) }
-    }
-}
-
-impl FromIterator<u32> for Bitmap {
-    /// Convenience method for creating bitmap from iterator.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Bitmap;
-    ///
-    /// let bitmap: Bitmap = (1..3).collect();
-    ///
-    /// assert!(!bitmap.is_empty());
-    /// assert!(bitmap.contains(1));
-    /// assert!(bitmap.contains(2));
-    /// assert_eq!(bitmap.cardinality(), 2);
-    /// ```
-    fn from_iter<I: IntoIterator<Item=u32>>(iter: I) -> Self {
-        Bitmap::of(&Vec::from_iter(iter))
-    }
-}
-
-impl<'a> IntoIterator for &'a Bitmap {
-    type Item = &'a u32;
-    type IntoIter = slice::Iter<'a, u32>;
-
-    /// Convenience method for creating iterators of the bitmap
-    /// elements.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use croaring::Bitmap;
-    ///
-    /// let bitmap: Bitmap = (1..3).collect();
-    ///
-    /// for (_, element) in bitmap.into_iter().enumerate() {
-    ///    assert!(bitmap.contains(*element));
-    /// }
-    /// ```
-    fn into_iter(self) -> Self::IntoIter {
-        self.as_slice().into_iter()
     }
 }
 


### PR DESCRIPTION
Returns Bitmap values in ascending order. Drops `Bitmap#into_iter()`, reason:
we cannot allow conversion into iterator with C based iterators as they modify
the underlying bitmap (https://github.com/RoaringBitmap/CRoaring/blob/2854bf777d6285994ea212f653cfadfce7afe83e/include/roaring/roaring.h#L450-L451).

Introduces `Bitmap#iter()` which allows to iterate over `Bitmap`. The Bitmap should not be modified while iterating.

Also: extracted iterator related functionality to `iter` module.