### PR TITLE
Bitmap#as_slice -> Bitmap#to_vec

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ println!("{:?}", rb1);
 rb3.add(5);
 rb3.or_inplace(&rb1);
 
-println!("{:?}", rb3.as_slice());
+println!("{:?}", rb3.to_vec());
 println!("{:?}", rb3);
 println!("{:?}", rb4);
 

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -300,7 +300,7 @@ fn bench_flip_inplace(b: &mut Bencher) {
 }
 
 #[bench]
-fn bench_as_slice(b: &mut Bencher) {
+fn bench_to_vec(b: &mut Bencher) {
     let mut bitmap = Bitmap::create();
 
     bitmap.add(1);
@@ -308,7 +308,7 @@ fn bench_as_slice(b: &mut Bencher) {
     bitmap.add(3);
 
     b.iter(|| {
-        bitmap.as_slice();
+        bitmap.to_vec();
     });
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@
 //! rb3.add(5);
 //! rb3.or_inplace(&rb1);
 //!
-//! println!("{:?}", rb3.as_slice());
+//! println!("{:?}", rb3.to_vec());
 //! println!("{:?}", rb3);
 //! println!("{:?}", rb4);
 //!

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,4 +1,3 @@
-use std::slice;
 use std::fmt;
 use std::ops::{BitAnd, BitAndAssign, BitOr, BitOrAssign, BitXor, BitXorAssign, Sub, SubAssign};
 
@@ -6,7 +5,7 @@ use {Bitmap, ffi};
 
 impl fmt::Debug for Bitmap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Bitmap<{:?}>", self.as_slice())
+        write!(f, "Bitmap<{:?}>", self.to_vec())
     }
 }
 

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -81,7 +81,7 @@ fn smoke2() {
     rb3.add(5);
     rb3.or_inplace(&rb1);
 
-    println!("{:?}", rb3.as_slice());
+    println!("{:?}", rb3.to_vec());
     println!("{:?}", rb3);
     println!("{:?}", rb4);
 
@@ -92,7 +92,7 @@ fn smoke2() {
 
 #[cfg(test)]
 fn cardinality_round(data: Vec<u32>) -> bool {
-    let original = Bitmap::of(data.as_slice());
+    let original = Bitmap::of(&data);
     let mut a = data.clone();
     a.sort();
     a.dedup();
@@ -109,7 +109,7 @@ fn cardinality_roundtrip() {
 }
 
 fn serialization_round_trip(original: Vec<u32>) -> bool {
-    let original = Bitmap::of(original.as_slice());
+    let original = Bitmap::of(&original);
 
     let buffer = original.serialize();
 


### PR DESCRIPTION
As reported - https://github.com/saulius/croaring-rs/issues/16 - fixes use after bug with with as_slice. `as_slice` is replaced with `to_vec`.

Fixes #16.