### PR TITLE
Set vec size when serializing bitmap

### DIFF
--- a/src/imp.rs
+++ b/src/imp.rs
@@ -572,10 +572,12 @@ impl Bitmap {
     /// ```
     #[inline]
     pub fn serialize(&self) -> Vec<u8> {
-        let mut dst = Vec::with_capacity(self.get_serialized_size_in_bytes());
+        let capacity = self.get_serialized_size_in_bytes();
+        let mut dst = Vec::with_capacity(capacity);
 
         unsafe {
             ffi::roaring_bitmap_portable_serialize(self.bitmap, dst.as_mut_ptr() as *mut ::libc::c_char);
+            dst.set_len(capacity);
         }
 
         dst

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -135,5 +135,6 @@ fn test_serialization_roundtrip() {
 
     let deserialized = Bitmap::deserialize(&buffer);
 
+    assert_eq!(buffer.len(), original.get_serialized_size_in_bytes());
     assert_eq!(original, deserialized);
 }


### PR DESCRIPTION
Before this fix, returned vec had length of 0. So one could not actually use serialized bitmap easily (without manually invoking set_len).