### PR TITLE
Implement Send and Sync for Bitmap

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,15 +53,18 @@
 //! println!("{:?}", rb4);
 //! ```
 
-extern crate libc;
 extern crate croaring_sys as ffi;
+extern crate libc;
 
 pub struct Bitmap {
     bitmap: *mut ffi::roaring_bitmap_s,
 }
 
+unsafe impl Sync for Bitmap {}
+unsafe impl Send for Bitmap {}
+
 pub type Statistics = ffi::roaring_statistics_s;
 
 mod imp;
-mod ops;
 mod iter;
+mod ops;


### PR DESCRIPTION
According CRoaring documentation (https://github.com/RoaringBitmap/CRoaring#thread-safety) Bitmap follows the semantic of Send and
Sync. Rust doesn't implement those traits for it, but it should be safe to
mark those traits as implemented.
Fixes  #37