### PR TITLE
Switch to cc crate

### DIFF
--- a/croaring-sys/Cargo.toml
+++ b/croaring-sys/Cargo.toml
@@ -13,5 +13,5 @@ description = "Raw bindings to CRoaring"
 libc = "0.2.42"
 
 [build-dependencies]
-gcc = "0.3.54"
+cc = "1.0"
 bindgen = "0.37.0"

--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -1,16 +1,16 @@
 extern crate bindgen;
-extern crate gcc;
+extern crate cc;
 
 use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    gcc::Build::new()
-      .flag("-std=c11")
-      .flag("-march=native")
-      .flag("-O3")
-      .file("CRoaring/roaring.c")
-      .compile("libroaring.a");
+    cc::Build::new()
+        .flag("-std=c11")
+        .flag("-march=native")
+        .flag("-O3")
+        .file("CRoaring/roaring.c")
+        .compile("libroaring.a");
 
     let bindings = bindgen::Builder::default()
         .blacklist_type("max_align_t")


### PR DESCRIPTION
gcc crate was renamed and marked as deprecated, this pr fixes a compiler
warning