### PR TITLE
WIP Get CRoaringRS working on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,26 +5,13 @@ dist: trusty
 language: rust
 
 os:
-  - linux
   - windows
 
-env:
-  matrix:
-   - LLVM_VERSION=3.8
-
 rust:
-  - nightly
-  - beta
   - stable
 
 before_script:
-  - wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
-  - echo "deb http://apt.llvm.org/precise/ llvm-toolchain-precise-$LLVM_VERSION main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get update -qq
-  - sudo apt-get install clang-$LLVM_VERSION
-  - sudo update-alternatives --install /usr/bin/cc cc /usr/bin/clang-$LLVM_VERSION 100
-  - sudo update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-$LLVM_VERSION 100
-  - git submodule update --init --recursive
+  - choco install llvm
 
 script:
   - (cd croaring-sys && cargo test)

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,7 @@ os:
   - windows
 
 rust:
-  - stable-gnu
-
-before_script:
-  - choco install llvm
+  - stable
 
 script:
   - cd croaring-sys && cargo test && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - windows
 
 env:
-  - CC=cc
+  - CC=gcc
 
 rust:
   - stable-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ os:
   - windows
 
 env:
-  - CC=gcc
+  - CC=clang
 
 rust:
   - stable-gnu

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,11 @@ os:
   - windows
 
 rust:
-  - stable
+  - stable-gnu
 
 before_script:
   - choco install llvm
 
 script:
-  - (cd croaring-sys && cargo test)
+  - cd croaring-sys && cargo test && cd ..
   - cargo test
-  - |
-    [ $TRAVIS_RUST_VERSION != nightly ] ||
-    cargo bench

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: rust
 
 os:
   - linux
+  - windows
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ os:
   - windows
 
 rust:
-  - stable
+  - stable-gnu
 
 script:
+  - set CC=cc
   - cd croaring-sys && cargo test && cd ..
   - cargo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ language: rust
 os:
   - windows
 
+env:
+  - CC=cc
+
 rust:
   - stable-gnu
 
 script:
-  - set CC=cc
   - cd croaring-sys && cargo test && cd ..
   - cargo test


### PR DESCRIPTION
CRoaring has windows builds set up as it is. This PR attempts to see what is required to get `croaring-rs` to build on windows MSVC and GNU toolchains if possible. 

This is part of getting [grin](https://github.com/mimblewimble/grin) ported to windows.
