### PR TITLE
Add bitmap.clear()

### DIFF
--- a/src/bitmap/imp.rs
+++ b/src/bitmap/imp.rs
@@ -226,7 +226,7 @@ impl Bitmap {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-      unsafe { ffi::roaring_bitmap_clear(self.bitmap) }
+        unsafe { ffi::roaring_bitmap_clear(self.bitmap) }
     }
 
     /// Clear the integer element from the bitmap
@@ -244,7 +244,7 @@ impl Bitmap {
     /// ```
     #[inline]
     pub fn remove(&mut self, element: u32) {
-      unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
+        unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
     }
 
     /// Remove the integer element from the bitmap. Returns true if a the value

--- a/src/bitmap/imp.rs
+++ b/src/bitmap/imp.rs
@@ -226,7 +226,7 @@ impl Bitmap {
     /// ```
     #[inline]
     pub fn clear(&mut self) {
-        unsafe { ffi::roaring_bitmap_clear(self.bitmap) }
+      unsafe { ffi::roaring_bitmap_clear(self.bitmap) }
     }
 
     /// Clear the integer element from the bitmap
@@ -242,10 +242,10 @@ impl Bitmap {
     ///
     /// assert!(bitmap.is_empty());
     /// ```
-        #[inline]
-        pub fn remove(&mut self, element: u32) {
-            unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
-        }
+    #[inline]
+    pub fn remove(&mut self, element: u32) {
+      unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
+    }
 
 
     /// Remove the integer element from the bitmap. Returns true if a the value

--- a/src/bitmap/imp.rs
+++ b/src/bitmap/imp.rs
@@ -247,7 +247,6 @@ impl Bitmap {
       unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
     }
 
-
     /// Remove the integer element from the bitmap. Returns true if a the value
     /// was removed, false if the value was present in the bitmap.
     ///

--- a/src/bitmap/imp.rs
+++ b/src/bitmap/imp.rs
@@ -220,14 +220,33 @@ impl Bitmap {
     ///
     /// let mut bitmap = Bitmap::create();
     /// bitmap.add(1);
-    /// bitmap.remove(1);
+    /// bitmap.clear();
     ///
     /// assert!(bitmap.is_empty());
     /// ```
     #[inline]
-    pub fn remove(&mut self, element: u32) {
-        unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
+    pub fn clear(&mut self) {
+        unsafe { ffi::roaring_bitmap_clear(self.bitmap) }
     }
+
+    /// Clear the integer element from the bitmap
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::Bitmap;
+    ///
+    /// let mut bitmap = Bitmap::create();
+    /// bitmap.add(1);
+    /// bitmap.remove(1);
+    ///
+    /// assert!(bitmap.is_empty());
+    /// ```
+        #[inline]
+        pub fn remove(&mut self, element: u32) {
+            unsafe { ffi::roaring_bitmap_remove(self.bitmap, element) }
+        }
+
 
     /// Remove the integer element from the bitmap. Returns true if a the value
     /// was removed, false if the value was present in the bitmap.

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -39,6 +39,9 @@ fn smoke1() {
     assert_eq!(bitmap.contains(u32::MAX - 2), true);
     assert_eq!(bitmap.contains(u32::MAX - 1), false);
     assert_eq!(bitmap.contains(u32::MAX), true);
+    bitmap.clear();
+    assert_eq!(bitmap.cardinality(), 0);
+    assert_eq!(bitmap.is_empty(), true);
 }
 
 // borrowed and adapted from https://github.com/Bitmap/gocroaring/blob/4a2fc02f79b1c36b904301e7d052f7f0017b6973/gocroaring_test.go#L24-L64


### PR DESCRIPTION
Adds call to bitmap clear which allows faster clearing without a re-allocation or in place intersection.