### PR TITLE
Add feature flag for maximum compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["RoaringBitmap", "croaring", "bitmap"]
 documentation = "https://docs.rs/croaring"
 
 [features]
-compat = []
+compat = ["croaring-sys/compat"]
 
 [dev-dependencies]
 proptest = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,9 @@ readme = "README.md"
 keywords = ["RoaringBitmap", "croaring", "bitmap"]
 documentation = "https://docs.rs/croaring"
 
+[features]
+compat = []
+
 [dev-dependencies]
 proptest = "0.9"
 roaring = "0.5.2"

--- a/croaring-sys/Cargo.toml
+++ b/croaring-sys/Cargo.toml
@@ -9,6 +9,9 @@ documentation = "https://docs.rs/croaring-sys"
 build = "build.rs"
 description = "Raw bindings to CRoaring"
 
+[features]
+compat = []
+
 [dependencies]
 libc = "0.2.42"
 

--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -5,10 +5,19 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    cc::Build::new()
+    let mut builder = cc::Build::new();
+    builder
         .flag_if_supported("-std=c11")
-        .flag_if_supported("-march=native")
-        .flag_if_supported("-O3")
+        .flag_if_supported("-O3");
+
+    if cfg!(feature = "compat") {
+        builder.define("DISABLEAVX", Some("1"));
+    }
+    else {
+        builder.flag_if_supported("-march=native");
+    }
+
+    builder
         .file("CRoaring/roaring.c")
         .compile("libroaring.a");
 


### PR DESCRIPTION
We use croaring-rs in a project and use a CI platform to build binaries. We'd like to maximize the compatibility of our binaries for older hardware, but by default croaring is being built with the `-march=native` flag and avx2 enabled, which might use cpu instructions that aren't supported by older architectures. This PR introduces an optional `compat` feature that turns those flags off.