### PR TITLE
Allow to specify target CPU architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ treemap2.add(std::u32::MAX as u64);
 treemap2.add(std::u64::MAX);
 ```
 
-### Building locally
+### Building
 
 ```
 git clone --recursive https://github.com/saulius/croaring-rs/
@@ -101,7 +101,14 @@ cd croaring-rs
 cargo build
 ```
 
-Tested on Rust [stable/beta/nightly and LLVM version 3.8](https://github.com/saulius/croaring-rs/blob/master/.travis.yml).
+As with [CRoaring](https://github.com/RoaringBitmap/CRoaring/) `croaring-rs`
+build allows the compiler to target the architecture of the build machine by
+using the `-march=native` flag. In this way the compiler is given freedom to
+use instructions that your CPU support. However binaries built this way can
+be dangerous to run on older CPU architectures (e.g. missing `POPCOUNT`
+instruction). You can specify `ROARING_ARCH` environment variable to control 
+the target CPU architecture, e.g.
+`ROARING_ARCH=ivybridge cargo build --release`.
 
 ### Testing
 

--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -5,12 +5,16 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    cc::Build::new()
-        .flag_if_supported("-std=c11")
-        .flag_if_supported("-march=native")
-        .flag_if_supported("-O3")
-        .file("CRoaring/roaring.c")
-        .compile("libroaring.a");
+    let mut build = cc::Build::new();
+    build.file("CRoaring/roaring.c");
+
+    if let Ok(target_arch) = env::var("ROARING_ARCH") {
+        build.flag_if_supported(&format!("-march={}", target_arch));
+    } else {
+        build.flag_if_supported("-march=native");
+    }
+
+    build.compile("libroaring.a");
 
     let bindings = bindgen::Builder::default()
         .blacklist_type("max_align_t")


### PR DESCRIPTION
If you build binaries on one machine and run them on a different one
it's possible that the latter machine might lack certain CPU
instructions of the build machine. In such instances `ROARING_ARCH`
environment variables allows to target end user machine's CPU
instruction set.

Also removed optimisation level as it's controlled by `cargo` build release mode and `cc-rs`.

Solves #60 #61