### PR TITLE
Implement a better Debug for the Bitmap

### DIFF
--- a/croaring/src/bitmap/ops.rs
+++ b/croaring/src/bitmap/ops.rs
@@ -5,7 +5,17 @@ use super::{ffi, Bitmap};
 
 impl fmt::Debug for Bitmap {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Bitmap<{:?}>", self.to_vec())
+        if self.cardinality() < 32 {
+            write!(f, "Bitmap<{:?}>", self.to_vec())
+        } else {
+            write!(
+                f,
+                "Bitmap<{:?} values between {:?} and {:?}>",
+                self.cardinality(),
+                self.minimum().unwrap(),
+                self.maximum().unwrap()
+            )
+        }
     }
 }
 


### PR DESCRIPTION
I found that displaying the debug format of a `Bitmap` was really slow when bitmaps were big, I found out that there wasn't any optimization on that, I implemented it.