### PR TITLE
Revert "Disable CI run on Windows"

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,8 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        #os: [ubuntu-latest, windows-latest, macos-latest]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         rust: [stable, nightly]
 
     steps:


### PR DESCRIPTION
49ac9ef says:

>Disable CI run on Windows
>
>Apparently Microsoft introduced a bug Visual Studio's distribution.
>More at:
>https://github.com/microsoft/STL/issues/1300
>
>Revert this when things get better.

I am pleased to report that things have gotten better (https://github.com/microsoft/STL/issues/1300#issuecomment-789542493) and excited to provide you with a revert. :)

This change passes CI for me: https://github.com/trevyn/croaring-rs/runs/2139234443

xref: https://github.com/mimblewimble/grin/pull/3596