### PR TITLE
Improvements to croaring-sys

### DIFF
--- a/croaring-sys/Cargo.toml
+++ b/croaring-sys/Cargo.toml
@@ -10,6 +10,9 @@ documentation = "https://docs.rs/croaring-sys"
 build = "build.rs"
 description = "Raw bindings to CRoaring"
 
+[lib]
+doctest = false
+
 [dependencies]
 libc = "0.2"
 

--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -2,6 +2,9 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
+    println!("cargo:rerun-if-changed=CRoaring");
+    println!("cargo:rerun-if-env-changed=ROARING_ARCH");
+
     let mut build = cc::Build::new();
     build.file("CRoaring/roaring.c");
 
@@ -9,12 +12,16 @@ fn main() {
         build.flag_if_supported(&format!("-march={}", target_arch));
     }
 
+    build.flag_if_supported("-Wno-unused-function");
     build.compile("libroaring.a");
 
     let bindings = bindgen::Builder::default()
         .header("CRoaring/roaring.h")
         .generate_inline_functions(true)
-        .generate_comments(false)
+        .allowlist_function("roaring.*")
+        .allowlist_type("roaring.*")
+        .allowlist_var("roaring.*")
+        .allowlist_var("ROARING.*")
         .generate()
         .expect("Unable to generate bindings");
 

--- a/croaring-sys/src/lib.rs
+++ b/croaring-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(rustdoc::bare_urls)]
 
 include!(concat!(env!("OUT_DIR"), "/croaring-sys.rs"));


### PR DESCRIPTION
* Use allowlists to only include roaring items
* Include docs
* Output extra cargo metadata to tell it about the environment variable
  our build script uses