### PR TITLE
Implement Extend for Bitmap and Treemap

### DIFF
--- a/croaring/src/bitmap/iter.rs
+++ b/croaring/src/bitmap/iter.rs
@@ -99,3 +99,11 @@ impl FromIterator<u32> for Bitmap {
         Bitmap::of(&Vec::from_iter(iter))
     }
 }
+
+impl Extend<u32> for Bitmap {
+    fn extend<T: IntoIterator<Item=u32>>(&mut self, iter: T) {
+        for item in iter {
+            self.add(item);
+        }
+    }
+}

--- a/croaring/src/treemap/iter.rs
+++ b/croaring/src/treemap/iter.rs
@@ -97,6 +97,16 @@ impl FromIterator<u64> for Treemap {
     /// assert_eq!(treemap.cardinality(), 11);
     /// ```
     fn from_iter<I: IntoIterator<Item = u64>>(iter: I) -> Self {
-        Treemap::of(&Vec::from_iter(iter))
+        let mut result = Self::create();
+        result.extend(iter);
+        result
+    }
+}
+
+impl Extend<u64> for Treemap {
+    fn extend<T: IntoIterator<Item=u64>>(&mut self, iter: T) {
+        for item in iter {
+            self.add(item);
+        }
     }
 }


### PR DESCRIPTION
Also, implement `FromIterator` for Treemap in terms of `Extend`, since `Treemap::of` just calls `add` repeatedly, there's no reason to collect into a vec first.