### PR TITLE
Unbox bitmap

### DIFF
--- a/croaring/src/bitmap/iter.rs
+++ b/croaring/src/bitmap/iter.rs
@@ -12,7 +12,7 @@ impl<'a> BitmapIterator<'a> {
     fn new(bitmap: &'a Bitmap) -> Self {
         let mut iterator = std::mem::MaybeUninit::uninit();
         unsafe {
-            ffi::roaring_init_iterator(bitmap.bitmap, iterator.as_mut_ptr());
+            ffi::roaring_init_iterator(&bitmap.bitmap, iterator.as_mut_ptr());
         }
         BitmapIterator {
             iterator: unsafe { iterator.assume_init() },

--- a/croaring/src/bitmap/mod.rs
+++ b/croaring/src/bitmap/mod.rs
@@ -54,7 +54,7 @@
 //! ```
 
 pub struct Bitmap {
-    bitmap: *mut ffi::roaring_bitmap_s,
+    bitmap: ffi::roaring_bitmap_t,
 }
 
 unsafe impl Sync for Bitmap {}


### PR DESCRIPTION
Rather than `Bitmap` being a wrapper over a heap allocated `*roaring_bitmap_t`, wrap the `roaring_bitmap_t` type directly. This matches the c++ wrapper, and should reduce pointer-chasing by a little bit.

I _think_ this is backwards compatible, but I wouldn't bet my life savings on that.