### PR TITLE
Pass only the base library name to cc::Build::compile

### DIFF
--- a/croaring-sys/build.rs
+++ b/croaring-sys/build.rs
@@ -13,7 +13,7 @@ fn main() {
     }
 
     build.flag_if_supported("-Wno-unused-function");
-    build.compile("libroaring.a");
+    build.compile("roaring");
 
     let bindings = bindgen::Builder::default()
         .header("CRoaring/roaring.h")


### PR DESCRIPTION
Per the [cc docs][1], we shouldn't be passing libroaring.a, and should instead
be passing just "roaring"

> The output string argument determines the file name for the compiled
> library. The Rust compiler will create an assembly named
> “lib”+output+“.a”. MSVC will create a file named output+“.lib”.
>
> For backwards compatibility, if output starts with “lib” and ends with
> “.a”, a second “lib” prefix and “.a” suffix do not get added on, but
> this usage is deprecated; please omit lib and .a in the argument that
> you pass.

[1]: https://docs.rs/cc/1.0.73/cc/struct.Build.html#method.compile