### PR TITLE
fix: use safe deserialization in roaring.h

### DIFF
--- a/croaring-sys/CRoaring/roaring.h
+++ b/croaring-sys/CRoaring/roaring.h
@@ -2918,6 +2918,7 @@ static inline void array_container_add_range_nvals(array_container_t *array,
                                                    uint32_t min, uint32_t max,
                                                    int32_t nvals_less,
                                                    int32_t nvals_greater) {
+    if (min > max || nvals_greater < 0 || nvals_greater > array->cardinality) return;
     int32_t union_cardinality = nvals_less + (max - min + 1) + nvals_greater;
     if (union_cardinality > array->capacity) {
         array_container_grow(array, union_cardinality, true);
@@ -2948,7 +2949,7 @@ nvals_less, nvals_greater);
  */
 static inline void array_container_remove_range(array_container_t *array,
                                                 uint32_t pos, uint32_t count) {
-    if (count != 0) {
+    if (count != 0 && pos + count <= (uint32_t)array->cardinality) {
         memmove(&(array->array[pos]), &(array->array[pos + count]),
                 (array->cardinality - pos - count) * sizeof(uint16_t));
         array->cardinality -= count;


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `croaring-sys/CRoaring/roaring.h`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `croaring-sys/CRoaring/roaring.h:2705` |
| **CWE** | CWE-502 |

**Description**: Multiple memmove calls in array container operations in roaring.h do not verify that computed indices (insert_idx, union_cardinality) are within the bounds of the allocated array buffer. An attacker who can supply crafted bitmap data — for example via the deserialization API — can manipulate cardinality or container metadata so that index calculations exceed the allocated capacity, causing writes beyond the heap buffer boundary.

## Changes
- `croaring-sys/CRoaring/roaring.h`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
