### PR TITLE
feat: add reverse and range bulk-read cursor methods

### DIFF
--- a/croaring/Cargo.toml
+++ b/croaring/Cargo.toml
@@ -29,7 +29,7 @@ criterion = { version = "0.8", features = ["html_reports"] }
 [dependencies]
 # Support for allocators that use allocator-api2
 allocator-api2 = { version = "0.4.0", optional = true, default-features = false, features = ["alloc"] }
-ffi = { package = "croaring-sys", path = "../croaring-sys", version = "4.6.1" }
+ffi = { package = "croaring-sys", path = "../croaring-sys", version = "4.7.0" }
 
 [[bench]]
 name = "benches"

--- a/croaring/src/bitmap/iter.rs
+++ b/croaring/src/bitmap/iter.rs
@@ -1,4 +1,5 @@
 use super::Bitmap;
+use crate::RangeInclusive;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 
@@ -299,6 +300,167 @@ impl<'a> BitmapCursor<'a> {
             unsafe { ffi::roaring_uint32_iterator_read(&mut self.raw, dst.as_mut_ptr(), count) };
         debug_assert!(result <= count);
         result as usize
+    }
+
+    /// Attempt to read many values from the iterator into `dst`, in reverse
+    ///
+    /// The current value _is_ included in the output.
+    ///
+    /// Returns the number of items read from the iterator, may be `< dst.len()` iff
+    /// the iterator is exhausted or `dst.len() > u32::MAX`.
+    ///
+    /// This can be much more efficient than repeated iteration.
+    ///
+    /// ```
+    /// use croaring::Bitmap;
+    ///
+    /// let mut bitmap = Bitmap::new();
+    /// bitmap.add_range(0..100);
+    /// bitmap.add(222);
+    /// bitmap.add(555);
+    /// bitmap.add(999);
+    ///
+    /// let mut buf = [0; 100];
+    /// let mut cursor = bitmap.cursor_to_last();
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 100);
+    /// for (i, item) in buf.iter().enumerate() {
+    ///     let expected = match i {
+    ///         0 => 999,
+    ///         1 => 555,
+    ///         2 => 222,
+    ///         _ => 99 - (i - 3)
+    ///     };
+    ///     assert_eq!(*item, expected as u32);
+    /// }
+    /// // Calls to next_many() can be interleaved with other cursor calls
+    /// assert_eq!(cursor.current(), Some(2));
+    /// assert_eq!(cursor.prev(), Some(1));
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 2);
+    /// assert_eq!(buf[0], 1);
+    /// assert_eq!(buf[1], 0);
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring_uint32_iterator_read_backward")]
+    #[must_use]
+    pub fn read_many_rev(&mut self, dst: &mut [u32]) -> usize {
+        let count = u32::try_from(dst.len()).unwrap_or(u32::MAX);
+        let result = unsafe {
+            ffi::roaring_uint32_iterator_read_backward(&mut self.raw, dst.as_mut_ptr(), count)
+        };
+        debug_assert!(result <= count);
+        result as usize
+    }
+
+    /// Attempt to read many ranges of consecutive values from the iterator into `dst`
+    ///
+    /// A range is a maximal interval of consecutive values: the set `{1, 2, 3, 5, 6}`
+    /// contains the two ranges `1..=3` and `5..=6`. The first range starts at the current
+    /// value, which _is_ included in the output.
+    ///
+    /// Returns the number of ranges written to `dst`, which may be `< dst.len()` if the
+    /// iterator is exhausted. After the call, the cursor is positioned just past the end of
+    /// the last range returned, or at the ghost position past the end if the bitmap is
+    /// exhausted.
+    ///
+    /// This can be much more efficient than reading individual values when the bitmap
+    /// contains long runs of consecutive values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::{Bitmap, RangeInclusive};
+    ///
+    /// let mut bitmap = Bitmap::new();
+    /// bitmap.add_range(0..100);
+    /// bitmap.add_range(200..300);
+    /// bitmap.add(555);
+    ///
+    /// let mut buf = [RangeInclusive::default(); 2];
+    /// let mut cursor = bitmap.cursor();
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 2);
+    /// assert_eq!((buf[0].start, buf[0].last), (0, 99));
+    /// assert_eq!((buf[1].start, buf[1].last), (200, 299));
+    /// // The cursor is positioned just past the last range returned
+    /// assert_eq!(cursor.current(), Some(555));
+    ///
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 1);
+    /// assert_eq!((buf[0].start, buf[0].last), (555, 555));
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring_uint32_iterator_read_ranges")]
+    #[must_use]
+    pub fn read_many_ranges(&mut self, dst: &mut [RangeInclusive<u32>]) -> usize {
+        let len = dst.len();
+        let dst_ptr = dst
+            .as_mut_ptr()
+            .cast::<ffi::roaring_uint32_range_closed_t>();
+
+        let result =
+            unsafe { ffi::roaring_uint32_iterator_read_ranges(&mut self.raw, dst_ptr, len) };
+        debug_assert!(result <= len);
+        result
+    }
+
+    /// Attempt to read many ranges of consecutive values from the iterator into `dst`, in reverse
+    ///
+    /// A range is a maximal interval of consecutive values: the set `{1, 2, 3, 5, 6}`
+    /// contains the two ranges `1..=3` and `5..=6`. The first range ends at the current
+    /// value, which _is_ included in the output.
+    ///
+    /// Ranges are written in descending order: `dst[0]` is the highest range (ending at the
+    /// current value) and each subsequent range lies below the previous one.
+    ///
+    /// Returns the number of ranges written to `dst`, which may be `< dst.len()` if the
+    /// iterator is exhausted. After the call, the cursor is positioned just before the start of
+    /// the last range returned, or at the ghost position past the front if the bitmap is
+    /// exhausted.
+    ///
+    /// This can be much more efficient than reading individual values when the bitmap
+    /// contains long runs of consecutive values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::{Bitmap, RangeInclusive};
+    ///
+    /// let mut bitmap = Bitmap::new();
+    /// bitmap.add(10);
+    /// bitmap.add_range(200..300);
+    /// bitmap.add_range(400..500);
+    ///
+    /// let mut buf = [RangeInclusive::default(); 2];
+    /// let mut cursor = bitmap.cursor_to_last();
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 2);
+    /// assert_eq!((buf[0].start, buf[0].last), (400, 499));
+    /// assert_eq!((buf[1].start, buf[1].last), (200, 299));
+    /// // The cursor is positioned just before the last range returned
+    /// assert_eq!(cursor.current(), Some(10));
+    ///
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 1);
+    /// assert_eq!((buf[0].start, buf[0].last), (10, 10));
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring_uint32_iterator_read_prev_ranges")]
+    #[must_use]
+    pub fn read_many_ranges_rev(&mut self, dst: &mut [RangeInclusive<u32>]) -> usize {
+        let len = dst.len();
+        let dst_ptr = dst
+            .as_mut_ptr()
+            .cast::<ffi::roaring_uint32_range_closed_t>();
+
+        let result =
+            unsafe { ffi::roaring_uint32_iterator_read_prev_ranges(&mut self.raw, dst_ptr, len) };
+        debug_assert!(result <= len);
+        result
     }
 
     /// Reset the iterator to the first value `>= val`

--- a/croaring/src/bitmap64/iter.rs
+++ b/croaring/src/bitmap64/iter.rs
@@ -1,4 +1,4 @@
-use crate::Bitmap64;
+use crate::{Bitmap64, RangeInclusive};
 use core::marker::PhantomData;
 use core::mem::{ManuallyDrop, MaybeUninit};
 use core::ptr::NonNull;
@@ -349,6 +349,164 @@ impl<'a> Bitmap64Cursor<'a> {
         debug_assert!(result <= count);
         self.has_value = unsafe { ffi::roaring64_iterator_has_value(self.raw.as_ptr()) };
         result as usize
+    }
+
+    /// Attempt to read many values from the iterator into `dst`, in reverse
+    ///
+    /// The current value _is_ included in the output.
+    ///
+    /// Returns the number of items read from the iterator, may be `< dst.len()` iff
+    /// the iterator is exhausted or `dst.len() > u64::MAX`.
+    ///
+    /// This can be much more efficient than repeated iteration.
+    ///
+    /// ```
+    /// use croaring::Bitmap64;
+    ///
+    /// let mut bitmap = Bitmap64::new();
+    /// bitmap.add_range(0..100);
+    /// bitmap.add(222);
+    /// bitmap.add(555);
+    /// bitmap.add(999);
+    ///
+    /// let mut buf = [0; 100];
+    /// let mut cursor = bitmap.cursor_to_last();
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 100);
+    /// for (i, item) in buf.iter().enumerate() {
+    ///     let expected = match i {
+    ///         0 => 999,
+    ///         1 => 555,
+    ///         2 => 222,
+    ///         _ => 99 - (i - 3)
+    ///     };
+    ///     assert_eq!(*item, expected as u64);
+    /// }
+    /// // Calls to read_many_rev() can be interleaved with other cursor calls
+    /// assert_eq!(cursor.current(), Some(2));
+    /// assert_eq!(cursor.prev(), Some(1));
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 2);
+    /// assert_eq!(buf[0], 1);
+    /// assert_eq!(buf[1], 0);
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_rev(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring64_iterator_read_backward")]
+    #[must_use]
+    pub fn read_many_rev(&mut self, dst: &mut [u64]) -> usize {
+        let count = u64::try_from(dst.len()).unwrap_or(u64::MAX);
+        let result = unsafe {
+            ffi::roaring64_iterator_read_backward(self.raw.as_ptr(), dst.as_mut_ptr(), count)
+        };
+        debug_assert!(result <= count);
+        self.has_value = unsafe { ffi::roaring64_iterator_has_value(self.raw.as_ptr()) };
+        result as usize
+    }
+
+    /// Attempt to read many ranges of consecutive values from the iterator into `dst`
+    ///
+    /// A range is a maximal interval of consecutive values: the set `{1, 2, 3, 5, 6}`
+    /// contains the two ranges `1..=3` and `5..=6`. The first range starts at the current
+    /// value, which _is_ included in the output.
+    ///
+    /// Returns the number of ranges written to `dst`, which may be `< dst.len()` if the
+    /// iterator is exhausted. After the call, the cursor is positioned just past the end of
+    /// the last range returned, or at the ghost position past the end if the bitmap is
+    /// exhausted.
+    ///
+    /// This can be much more efficient than reading individual values when the bitmap
+    /// contains long runs of consecutive values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::{Bitmap64, RangeInclusive};
+    ///
+    /// let mut bitmap = Bitmap64::new();
+    /// bitmap.add_range(0..100);
+    /// bitmap.add_range(200..300);
+    /// bitmap.add(555);
+    ///
+    /// let mut buf = [RangeInclusive::default(); 2];
+    /// let mut cursor = bitmap.cursor();
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 2);
+    /// assert_eq!((buf[0].start, buf[0].last), (0, 99));
+    /// assert_eq!((buf[1].start, buf[1].last), (200, 299));
+    /// // The cursor is positioned just past the last range returned
+    /// assert_eq!(cursor.current(), Some(555));
+    ///
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 1);
+    /// assert_eq!((buf[0].start, buf[0].last), (555, 555));
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_ranges(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring64_iterator_read_ranges")]
+    #[must_use]
+    pub fn read_many_ranges(&mut self, dst: &mut [RangeInclusive<u64>]) -> usize {
+        let len = dst.len();
+        let dst_ptr = dst.as_mut_ptr().cast::<ffi::roaring64_range_closed_t>();
+
+        let result =
+            unsafe { ffi::roaring64_iterator_read_ranges(self.raw.as_ptr(), dst_ptr, len) };
+        self.has_value = unsafe { ffi::roaring64_iterator_has_value(self.raw.as_ptr()) };
+        result
+    }
+
+    /// Attempt to read many ranges of consecutive values from the iterator into `dst`, in reverse
+    ///
+    /// A range is a maximal interval of consecutive values: the set `{1, 2, 3, 5, 6}`
+    /// contains the two ranges `1..=3` and `5..=6`. The first range ends at the current
+    /// value, which _is_ included in the output.
+    ///
+    /// Ranges are written in descending order: `dst[0]` is the highest range (ending at the
+    /// current value) and each subsequent range lies below the previous one.
+    ///
+    /// Returns the number of ranges written to `dst`, which may be `< dst.len()` if the
+    /// iterator is exhausted. After the call, the cursor is positioned just before the start of
+    /// the last range returned, or at the ghost position past the front if the bitmap is
+    /// exhausted.
+    ///
+    /// This can be much more efficient than reading individual values when the bitmap
+    /// contains long runs of consecutive values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use croaring::{Bitmap64, RangeInclusive};
+    ///
+    /// let mut bitmap = Bitmap64::new();
+    /// bitmap.add(10);
+    /// bitmap.add_range(200..300);
+    /// bitmap.add_range(400..500);
+    ///
+    /// let mut buf = [RangeInclusive::default(); 2];
+    /// let mut cursor = bitmap.cursor_to_last();
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 2);
+    /// assert_eq!((buf[0].start, buf[0].last), (400, 499));
+    /// assert_eq!((buf[1].start, buf[1].last), (200, 299));
+    /// // The cursor is positioned just before the last range returned
+    /// assert_eq!(cursor.current(), Some(10));
+    ///
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 1);
+    /// assert_eq!((buf[0].start, buf[0].last), (10, 10));
+    ///
+    /// assert_eq!(cursor.current(), None);
+    /// assert_eq!(cursor.read_many_ranges_rev(&mut buf), 0);
+    /// ```
+    #[inline]
+    #[doc(alias = "roaring64_iterator_read_prev_ranges")]
+    #[must_use]
+    pub fn read_many_ranges_rev(&mut self, dst: &mut [RangeInclusive<u64>]) -> usize {
+        let len = dst.len();
+        let dst_ptr = dst.as_mut_ptr().cast::<ffi::roaring64_range_closed_t>();
+
+        let result =
+            unsafe { ffi::roaring64_iterator_read_prev_ranges(self.raw.as_ptr(), dst_ptr, len) };
+        self.has_value = unsafe { ffi::roaring64_iterator_has_value(self.raw.as_ptr()) };
+        result
     }
 
     /// Reset the iterator to the first value `>= val`

--- a/croaring/src/lib.rs
+++ b/croaring/src/lib.rs
@@ -27,6 +27,8 @@ mod sealed {
     pub trait Sealed {}
 }
 
+use core::mem::offset_of;
+use core::ops::Bound;
 pub use serialization::*;
 
 pub use bitmap::{Bitmap, BitmapView};
@@ -40,3 +42,72 @@ pub use treemap::Treemap;
 pub use rust_alloc::configure_custom_alloc;
 #[cfg(feature = "alloc")]
 pub use rust_alloc::configure_rust_alloc;
+
+/// An inclusive range
+///
+/// `RangeInclusive<u32>` is guaranteed to be ABI compatible with `roaring_uint32_range_closed_t`,
+/// `RangeInclusive<u64>` is guaranteed to be ABI compatible with `roaring64_range_closed_t`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[repr(C)]
+pub struct RangeInclusive<Idx> {
+    /// The lower bound of the range (inclusive).
+    pub start: Idx,
+    /// The upper bound of the range (inclusive).
+    pub last: Idx,
+}
+impl<Idx> From<core::ops::RangeInclusive<Idx>> for RangeInclusive<Idx> {
+    fn from(value: core::ops::RangeInclusive<Idx>) -> Self {
+        let (start, last) = value.into_inner();
+        Self { start, last }
+    }
+}
+
+impl<Idx> From<RangeInclusive<Idx>> for core::ops::RangeInclusive<Idx> {
+    fn from(value: RangeInclusive<Idx>) -> Self {
+        core::ops::RangeInclusive::new(value.start, value.last)
+    }
+}
+
+impl<Idx> From<core::range::RangeInclusive<Idx>> for RangeInclusive<Idx> {
+    fn from(value: core::range::RangeInclusive<Idx>) -> Self {
+        let core::range::RangeInclusive { start, last } = value;
+        Self { start, last }
+    }
+}
+
+impl<Idx> From<RangeInclusive<Idx>> for core::range::RangeInclusive<Idx> {
+    fn from(value: RangeInclusive<Idx>) -> Self {
+        let RangeInclusive { start, last } = value;
+        core::range::RangeInclusive { start, last }
+    }
+}
+
+impl<Idx> core::ops::RangeBounds<Idx> for RangeInclusive<Idx> {
+    fn start_bound(&self) -> Bound<&Idx> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&Idx> {
+        Bound::Included(&self.last)
+    }
+}
+
+const _: () = {
+    type FFIRange = ffi::roaring_uint32_range_closed_t;
+    type RustRange = RangeInclusive<u32>;
+
+    assert!(size_of::<FFIRange>() == size_of::<RustRange>());
+    assert!(align_of::<FFIRange>() == align_of::<RustRange>());
+    assert!(offset_of!(FFIRange, min) == offset_of!(RustRange, start));
+    assert!(offset_of!(FFIRange, max) == offset_of!(RustRange, last));
+};
+
+const _: () = {
+    type FFIRange = ffi::roaring64_range_closed_t;
+    type RustRange = RangeInclusive<u64>;
+
+    assert!(size_of::<FFIRange>() == size_of::<RustRange>());
+    assert!(align_of::<FFIRange>() == align_of::<RustRange>());
+    assert!(offset_of!(FFIRange, min) == offset_of!(RustRange, start));
+    assert!(offset_of!(FFIRange, max) == offset_of!(RustRange, last));
+};


### PR DESCRIPTION
Expose the iterator helpers added in CRoaring 4.7.0 as safe methods on both BitmapCursor and Bitmap64Cursor:

- read_many_rev          (roaring_*_iterator_read_backward)
- read_many_ranges       (roaring_*_iterator_read_ranges)
- read_many_ranges_rev   (roaring_*_iterator_read_prev_ranges)

The range methods read maximal runs of consecutive values into a new `RangeInclusive<Idx>` type, which is repr(C) and ABI-compatible with `roaring_uint32_range_closed_t` / `roaring64_range_closed_t` (enforced by const ABI asserts). It implements RangeBounds, so ranges read back from a cursor can be passed straight to add_range, contains_range, flip, etc., and converts to/from both core::ops and core::range RangeInclusive.

Bumps the croaring-sys dependency to 4.7.0.